### PR TITLE
VLANs for networking

### DIFF
--- a/general_rules/Scenario.tex
+++ b/general_rules/Scenario.tex
@@ -212,12 +212,24 @@ Typical names are, for example, James, John, Robert, Michael and William as male
 For wireless communication, an \iterm{arena network} is provided. The actual infrastructure depends on the local organization. 
 
 \begin{itemize}
-	\item To avoid interference with other leagues, this WiFi has to be used for communication only. It is not allowed to use the above or any other WiFi network for personal use at the venue.
+	\item To avoid interference with other leagues, this \iterm{arena network} has to be used for communication only. 
+	  It is not allowed to use the above or any other WiFi network for personal use at the venue.
 	\item During the competitions, only the active team is allowed to use the \iterm{arena network}. 
-	\item The organizers cannot guarantee reliability and performance of wireless communication. Therefore, teams are required to be ready to setup, start their robots and run the tests even if, for any reason, network is not working properly.
+	\item The organizers cannot guarantee reliability and performance of wireless communication. 
+	  Therefore, teams are required to be ready to setup, start their robots and run the tests even if, for any reason, network is not working properly.
 \end{itemize}
 
-Preferably the organizers will try to provide one LAN cable on the desk of each participating team for Internet connection. However, this cannot be guaranteed. If multiple LAN connections are needed, each team has to bring its own LAN hub/switch and cables.
+Preferred situation:
+\begin{itemize}
+ \item The \iterm{arena network} consists of of several Virtual Local Area Networks (VLANs), one for each team. 
+ \item The traffic from the robot inside the arena is separated into the corresponding team's VLAN as soon as possible, e.g. at the wireless acces point. 
+  This may require that each team has it's own SSID, each of which gets routed into the corresponding VLAN
+  Each team has a network cable routed to their team area, which is also connected to the teams VLAN. 
+  On this cable, the team can set up their own router/switch/hub etc. which will be inside the team's VLAN.
+  This way, one team's traffic and devices are completely separated from any other team, while any team can set up their own DHCP server etc. if they desire. 
+ \item An Internet connection is preferably also available for every team. 
+\end{itemize}
+Each team has to bring its own LAN hub/switch and cables for routing inside the team area. 
 
 \paragraph*{Important note:} Any unapproved wireless device may be removed by the TC at any time.
 

--- a/general_rules/Scenario.tex
+++ b/general_rules/Scenario.tex
@@ -231,6 +231,12 @@ Preferred situation:
 \end{itemize}
 Each team has to bring its own LAN hub/switch and cables for routing inside the team area. 
 
+In case the \iterm{arena network} is not functioning at the end of the first setup day, teams are allowed to set up their own networking equipment and wireless networks.
+
+\paragraph*{Important note:} Different countries have different regulations for wireless equipment and the \iterm{arena network} has to obey these. 
+It is up to the teams to have networking equipment that also adheres to these regulations.
+For example, if due to local regulations various WiFi channels are prohibited, it is a team's responsibility to be able to use different, allowed channels.
+
 \paragraph*{Important note:} Any unapproved wireless device may be removed by the TC at any time.
 
 \subsection{Smart Home Devices}


### PR DESCRIPTION
So, we had a chat about the @Home network today (July 2, 2016), the TC (me) and some people of Homer, TechUnited and ToBi.

The setup decided on is using a VLAN with a managed switch:

The teams register the MAC addresses of their WiFi-enabled devices: with a reasonable max per team. We will not register all the team laptops, just the bare minimum: their robot(s) and 1 or 2 laptops and perhaps a tablet.
There is a central switch, with ca. 40 Gigabit ethernet ports
Each arena has a wireless access point with its own SSID
From the central switch, there goes 1 cable to each team table. They can do whatever they want on that cable. Everything on that cable (so of that particular team) always gets routed to the MAC-addresses associated with that team, via a Virtual LAN.
The refbox (to be, in the future) is also connected to every VLAN so all the teams can access it.
Teams teams can put a switch, router with DHCP server on their table and plug the cable from the central switch into it. And also plug a different cable with internet access into the same router.
For this, we'll need a managed switch, with the following requirements:

- VLAN-capable
- 40 ports or so
- Perhaps a firewall to limit internet access of the robots
The estimated cost (when bought new) of such a thing is in the 5000-10000 euro range.