### PR TITLE
2017/cocktail party

### DIFF
--- a/Rulebook.tex
+++ b/Rulebook.tex
@@ -156,6 +156,9 @@ Robot should be ready to start the next attempt to the same test as fast as poss
 \newpage
 \input{tests/StoringGroceries}
 
+\newpage
+\input{tests/CocktailParty}
+
 % \newpage
 % \input{tests/Navigation}
 

--- a/score_sheets.tex
+++ b/score_sheets.tex
@@ -117,6 +117,11 @@
 \input{scoresheets/StoringGroceries.tex}
 \end{scoresheet}
 
+\renewcommand{\currentTest}{Cocktail Party}
+\begin{scoresheet}
+\input{scoresheets/CocktailParty.tex}
+\end{scoresheet}
+
 \renewcommand{\currentTest}{Navigation}
 \begin{scoresheet}
 \input{scoresheets/Navigation.tex}

--- a/scoresheets/CocktailParty.tex
+++ b/scoresheets/CocktailParty.tex
@@ -1,0 +1,35 @@
+The maximum time for this test is 5 minutes.
+
+\begin{scorelist}
+	\scoreheading{Taking the orders} % 90 = 30 + 30 + 15 + 15
+	\scoreitem[2]{15}{Detecting calling person}
+	\scoreitem{30}{Finding sitting \& distracted person}
+	\scoreitem[3]{ 5}{Understanding and repeating the correct person's name}
+	\scoreitem[3]{ 5}{Understanding and repeating the correct drink's name}
+
+	\scoreheading{Placing orders} % 105 = 15 + 90
+	\scoreitem[3]{ 5}{Repeat the correct name \& drink to the Barman }
+	\scoreitem[3]{30}{Provide an accurate description of the guest to the Barman}
+
+	\scoreheading{Missing beverage} % 40
+	\scoreitem{20}{Realize the missing drink}
+	\scoreitem{20}{Provide 3 available alternatives to the Barman}
+	\scoreitem{ 5}{Understanding and repeating the alternatives to the Barman}
+
+	\scoreheading{Correcting the order} % 35 = 20 + 5 + 5 + 5
+	\scoreitem{20}{Find the guest without calling them}
+	\scoreitem{10}{Find the guest by calling them}
+	\scoreitem{ 5}{Repeat the correct list of alternate drinks to the guest}
+	\scoreitem{ 5}{Understanding and repeating the corrected order}
+	\scoreitem{ 5}{Place the corrected order} % Speed bonus
+
+	\scoreheading{Penalties}
+	\scoreitem[-1]{20}{Talk to something that is not a human}
+	
+	\setTotalScore{270}
+\end{scorelist}
+
+
+% Local Variables:
+% TeX-master: "Rulebook"
+% End:

--- a/tests/CocktailParty.tex
+++ b/tests/CocktailParty.tex
@@ -1,0 +1,82 @@
+\section{Cocktail Party [SSPL only]}
+
+The robot has to learn and recognize previously unknown people, and fetch orders.
+
+\subsection{Focus}
+
+This test focuses on human detection and recognition, safe navigation and human-robot interaction with unknown people.
+
+\subsection{Setup}
+	\item \textbf{Guests:} Five people are distributed in a predefined \quotes{party room} either sitting or standing, some of them forming groups of 2 or 3 people. At least one guest out of the five is sitting. Three out of five guests have drinks orders assigned by the referees. The sitting person always has an assigned drink.
+
+\subsection{Task}
+
+\begin{enumerate}
+
+	\item \textbf{Entering:} The robot enters the arena and navigates to the party room and waits for being called.
+
+	\item \textbf{Getting called:} The guests call the robot simultaneously, either rising an arm, waving, or shouting. The robot has to approach one of them.
+	% Remark: Themself is the correct word used instead of himself/herself  when person gender is unknown.
+	The calling person introduces themself by name before giving the order of a drink. The robot leads the dialogue to learn the person and retrieve their drink order. \\
+
+	The robot can decide to skip the detection of the calling and ask one person to walk in front of it. In this case, the referees determine the person to approach the robot.
+
+	\item \textbf{Sitting person:} At least one person is sitting and minding their own business (i.e. not looking directly to the robot). The robot must locate that person and ask if the person wants something to drink. The robot must also ask for the person's name and memorize them (i.e. execute a learning procedure of the name and the person's features).
+
+	\item \textbf{Taking the order:} The guest asks for a specific drink to the robot. The robot can fetch more orders (i.e.~ find next calling guest or looking for the sitting one) or proceed to place the order. In the first case, the robot searches for the remaining calling people. During the search process, the robot is allowed to either ask people to call for it again, or to ask people to come to it and to give a new order. In both cases the robot may call into the room.
+
+	\item \textbf{Getting the drinks:} The robot has to navigate to a designated location in another \quotes{storage room} where drinks are stored. The robot may grasp any number of drinks, e.g., all the drinks ordered, or just one, and return to the party room.
+
+	\item \textbf{Delivering the drinks:} While the robot fetches drinks, the people may change their places within the party room (on request of the referees). The robot has to search for people, recognize found people, and deliver the correct drink if there is an order for the recognized person. If the robot comes to the place the person ordered and the person is not there, then it could call the person loud, the person should respond (either sound or waving hand) and the robot must go to that place (check the person identity).
+
+	\item \textbf{Leaving the arena:} After delivering all the drinks, the robot has to leave the arena.
+\end{enumerate}
+
+\subsection{Additional rules and remarks}
+\begin{enumerate}
+	\item \textbf{Repeating names:} The robot may ask to repeat the name if it has not understood it.
+
+	\item \textbf{Misunderstood names:} If the robot misunderstands the name, the understood (wrong) name is used in the remainder of this test.
+
+	\item \textbf{Misunderstood order:} If the robot does not understand the order, it can continue with an own assignment of drinks to people or with a wrong, misunderstood assignment.
+
+	\item \textbf{Approaching non-calling people:} If the robot approaches a person that is not calling and asks for an order, the person indicates that she/he does not want to order anything. No points can be scored for understanding names or orders, or for grasping or delivery for a non-calling person.
+
+	\item \textbf{Changing places:} After giving the order (when the robot is not in the party room), the referees may re-arrange the people including their body posture. That is, a sitting person may change to a standing posture and vice versa.
+
+	\item \textbf{Positions and orientations:} All people roughly stay where they are (if not asked to move by the referees), but they are allowed to move in certain limits (e.g. turn around, make a step aside). They do not need to look at the robot, but are requested to do so, when instructed by the robot.
+
+	\item \textbf{Asking for help:} If the robot fails to grasp a drink, the robot may ask for help and a referee can hand over the object (loosing points for grasping). The robot has to clearly indicate that it has recognized the correct drink, e.g., by facing the drink, naming it and telling its rough position (e.g., leftmost, rightmost etc.) relative to the other drinks on the table.
+
+	\item \textbf{Correct delivery:} The drinks do not have to be handed over to the user. Putting them on the ground or asking the user to grab them from some kind of tray is allowed. When taking a drink from the robot, a sitting person may stand up in order to get it. However, in case the robot is carrying more than one object at a time, a delivery is only considered successful when there is an easily comprehensible mapping from grasped objects to recognized people. The robot must be close to the person (within 1 m) for delivery and indicate uniquely which person it addresses by calling it by name and either facing her/him or pointing at her/him (e.g., with object in hand). When putting all the drinks on a tray, the robot has to name the correct drink and indicate its rough position relative to the others.
+
+	\item \textbf{Empty arena:} During the test, only the robot and only 5 people are in the arena. The door opener, the referees and other personnel that is not assigned as test people will be outside the scenario.
+
+	\item \textbf{Calling instruction:} The team needs to specify before the test which ways of getting the attention of the robot are allowed. This can be waving, calling or both of them. The robot can also decide to skip this part, by asking for people to get close to it.
+
+	\item \textbf{Announcement of locations:} Both the locations of the drinks and the rooms where the test takes place are announced beforehand. Note that there may be more objects at the drink location than the ordered drinks.
+\end{enumerate}
+
+\subsection{Referee instructions}
+
+The referees need to
+\begin{itemize}
+	\item select 5 people and their names from the list of person names (see Section 3.2.8),
+	\item arrange (and re-arrange) people in the party room,
+	\item place 5 drinks at the pick location in the storage room,
+	\item select the ordering 3 people and the orders to give,
+	\item in case the robot skips the calling detection, select the ordering person to approach the robot,
+	\item write down the understood names and drinks during an order and update the order accordingly.
+\end{itemize}
+
+\subsection{OC instructions}
+
+2h before test:
+\begin{itemize}
+	\item Specify and announce the rooms where the test takes place.
+	\item Specify and announce the location where the drinks are placed.
+\end{itemize}
+
+% \newpage 
+% \subsection{Score sheet}
+% \input{scoresheets/CocktailParty.tex}

--- a/tests/CocktailParty.tex
+++ b/tests/CocktailParty.tex
@@ -7,7 +7,12 @@ The robot has to learn and recognize previously unknown people, and fetch orders
 This test focuses on human detection and recognition, safe navigation and human-robot interaction with unknown people.
 
 \subsection{Setup}
-	\item \textbf{Guests:} Five people are distributed in a predefined \quotes{party room} either sitting or standing, some of them forming groups of 2 or 3 people. At least one guest out of the five is sitting. Three out of five guests have drinks orders assigned by the referees. The sitting person always has an assigned drink.
+\begin{itemize}
+	\item \textbf{Party room}: any (large) room inside the apartment when normally a party would be held.
+	\item \textbf{Guests:} At least five people are distributed in a predefined \quotes{party room} either sitting or standing, some of them forming groups of 2 or 3 people, from which at least one is sitting. Three of the guests have drink orders assigned by the referees. The sitting person always has an assigned drink.
+	\item \textbf{Bar:} The bar is any flat surface where objects can be placed, in a room other than the \quotes{party room}. All available beverages are on top of the bar for the robot can see them.
+	\item \textbf{Barman:} The Barman bay be standing either behind the bar or next to it, depending on the arena setup.
+\end{itemize}
 
 \subsection{Task}
 
@@ -21,15 +26,26 @@ This test focuses on human detection and recognition, safe navigation and human-
 
 	The robot can decide to skip the detection of the calling and ask one person to walk in front of it. In this case, the referees determine the person to approach the robot.
 
-	\item \textbf{Sitting person:} At least one person is sitting and minding their own business (i.e. not looking directly to the robot). The robot must locate that person and ask if the person wants something to drink. The robot must also ask for the person's name and memorize them (i.e. execute a learning procedure of the name and the person's features).
+	\item \textbf{Taking the order:} After the robot has fetched the order of the first guest, it can either fetch more orders (i.e.~ find next calling guest or looking for the sitting one) or proceed to place the order. In the first case, the robot searches for the remaining calling people. During the search process, the robot is allowed to either ask people to call for it again, or to ask people to come to it and to give a new order. In both cases the robot may call into the room.
 
-	\item \textbf{Taking the order:} The guest asks for a specific drink to the robot. The robot can fetch more orders (i.e.~ find next calling guest or looking for the sitting one) or proceed to place the order. In the first case, the robot searches for the remaining calling people. During the search process, the robot is allowed to either ask people to call for it again, or to ask people to come to it and to give a new order. In both cases the robot may call into the room.
+	\item \textbf{Sitting person:} At least one person is sitting and minding their own business (i.e. not looking directly to the robot). The robot must locate that person and ask if the person wants something to drink. The robot must also ask for the person's name and memorize them (i.e. execute a learning procedure of the name and the person's features). \\
 
-	\item \textbf{Getting the drinks:} The robot has to navigate to a designated location in another \quotes{storage room} where drinks are stored. The robot may grasp any number of drinks, e.g., all the drinks ordered, or just one, and return to the party room.
+	\textbf{Remark:} At least one sitting person has an order to place. No sitting person will not attend robot's call.
 
-	\item \textbf{Delivering the drinks:} While the robot fetches drinks, the people may change their places within the party room (on request of the referees). The robot has to search for people, recognize found people, and deliver the correct drink if there is an order for the recognized person. If the robot comes to the place the person ordered and the person is not there, then it could call the person loud, the person should respond (either sound or waving hand) and the robot must go to that place (check the person identity).
+	\item \textbf{Placing the orders:} The robot has to navigate to the \textit{Bar}, a designated location in another room where drinks are served. The robot must repeat each order to the \textit{Barman}, clearly stating:
+	\begin{enumerate}
+		\item The person's name,
+		\item The person's chosen drink,
+		\item A description of unique characteristics of that person that allow the \textit{Barman} to find them (e.g. gender, hair colour, how is dressed, etc).
+	\end{enumerate}
 
-	\item \textbf{Leaving the arena:} After delivering all the drinks, the robot has to leave the arena.
+	While the robot places the orders, the people may change their places within the party room (on request of the referees).
+
+	\item \textbf{Correcting the order:} One of the ordered drinks is not available. The barman will clearly state which of the beverages is not available and provide a list of 3 alternatives. The robot should navigate back to the \quotes{party room}, find the person whose drink is missing and provide the alternatives for they to choose.\\
+
+	If the robot comes to the place the person ordered and the person is not there, it can call that person loud, the person should respond (either sound or waving hand) and the robot must go to that place (check the person identity).
+
+	\item \textbf{Placing the corrected order:} The robot has to navigate to the \textit{Bar} and inform the change on the guest's order. This time only the guest's name and drink can be provided.
 \end{enumerate}
 
 \subsection{Additional rules and remarks}
@@ -40,21 +56,17 @@ This test focuses on human detection and recognition, safe navigation and human-
 
 	\item \textbf{Misunderstood order:} If the robot does not understand the order, it can continue with an own assignment of drinks to people or with a wrong, misunderstood assignment.
 
-	\item \textbf{Approaching non-calling people:} If the robot approaches a person that is not calling and asks for an order, the person indicates that she/he does not want to order anything. No points can be scored for understanding names or orders, or for grasping or delivery for a non-calling person.
+	\item \textbf{Approaching non-calling people:} If the robot approaches a person that is not calling and asks for an order, the person indicates that they does not want to order anything. No points can be scored for understanding names or orders, or for grasping or delivery for a non-calling person.
+
+	\item \textbf{Guest description:} The guest's description must be unique inside the scenario. For instance, it make no sense to state that a person is wearing a red T-shirt if two people are wearing them. In the same sense, stating that the ordering guest is \textit{tall} can lead to confusion, but stating that is the \textit{tallest} does not.
 
 	\item \textbf{Changing places:} After giving the order (when the robot is not in the party room), the referees may re-arrange the people including their body posture. That is, a sitting person may change to a standing posture and vice versa.
 
 	\item \textbf{Positions and orientations:} All people roughly stay where they are (if not asked to move by the referees), but they are allowed to move in certain limits (e.g. turn around, make a step aside). They do not need to look at the robot, but are requested to do so, when instructed by the robot.
 
-	\item \textbf{Asking for help:} If the robot fails to grasp a drink, the robot may ask for help and a referee can hand over the object (loosing points for grasping). The robot has to clearly indicate that it has recognized the correct drink, e.g., by facing the drink, naming it and telling its rough position (e.g., leftmost, rightmost etc.) relative to the other drinks on the table.
-
-	\item \textbf{Correct delivery:} The drinks do not have to be handed over to the user. Putting them on the ground or asking the user to grab them from some kind of tray is allowed. When taking a drink from the robot, a sitting person may stand up in order to get it. However, in case the robot is carrying more than one object at a time, a delivery is only considered successful when there is an easily comprehensible mapping from grasped objects to recognized people. The robot must be close to the person (within 1 m) for delivery and indicate uniquely which person it addresses by calling it by name and either facing her/him or pointing at her/him (e.g., with object in hand). When putting all the drinks on a tray, the robot has to name the correct drink and indicate its rough position relative to the others.
-
-	\item \textbf{Empty arena:} During the test, only the robot and only 5 people are in the arena. The door opener, the referees and other personnel that is not assigned as test people will be outside the scenario.
-
+	\item \textbf{Empty arena:} During the test, only the robot, the guest, and the Barman are in the arena. The door opener, the referees and other personnel that is not assigned as test people will be outside the scenario.
+	
 	\item \textbf{Calling instruction:} The team needs to specify before the test which ways of getting the attention of the robot are allowed. This can be waving, calling or both of them. The robot can also decide to skip this part, by asking for people to get close to it.
-
-	\item \textbf{Announcement of locations:} Both the locations of the drinks and the rooms where the test takes place are announced beforehand. Note that there may be more objects at the drink location than the ordered drinks.
 \end{enumerate}
 
 \subsection{Referee instructions}
@@ -63,7 +75,7 @@ The referees need to
 \begin{itemize}
 	\item select 5 people and their names from the list of person names (see Section 3.2.8),
 	\item arrange (and re-arrange) people in the party room,
-	\item place 5 drinks at the pick location in the storage room,
+	\item select the person (barman) who will serve the drinks,
 	\item select the ordering 3 people and the orders to give,
 	\item in case the robot skips the calling detection, select the ordering person to approach the robot,
 	\item write down the understood names and drinks during an order and update the order accordingly.
@@ -74,9 +86,9 @@ The referees need to
 2h before test:
 \begin{itemize}
 	\item Specify and announce the rooms where the test takes place.
-	\item Specify and announce the location where the drinks are placed.
+	\item Specify and announce the location where the drinks are served.
 \end{itemize}
 
 % \newpage 
-% \subsection{Score sheet}
-% \input{scoresheets/CocktailParty.tex}
+\subsection{Score sheet}
+\input{scoresheets/CocktailParty.tex}

--- a/tests/CocktailParty.tex
+++ b/tests/CocktailParty.tex
@@ -39,9 +39,11 @@ This test focuses on human detection and recognition, safe navigation and human-
 		\item A description of unique characteristics of that person that allow the \textit{Barman} to find them (e.g. gender, hair colour, how is dressed, etc).
 	\end{enumerate}
 
-	While the robot places the orders, the people may change their places within the party room (on request of the referees).
+	While the robot places the orders, the people in the \quotes{party room} may change their places within the party room (on request of the referees).
 
-	\item \textbf{Correcting the order:} One of the ordered drinks is not available. The barman will clearly state which of the beverages is not available and provide a list of 3 alternatives. The robot should navigate back to the \quotes{party room}, find the person whose drink is missing and provide the alternatives for they to choose.\\
+	\item \textbf{Missing beverage:} One of the ordered drinks is not available, therefore, missing from the bar. The robot should realize this inconvenience and tell the \textit{Barman}, providing a list of 3 alternatives considering the other drinks it needs to deliver. If the robot can't detect which drink is missing, the \textit{Barman} will clearly state which of the beverages is not available and provide a list of 3 alternatives.
+
+	\item \textbf{Correcting an order:} The robot should navigate back to the \quotes{party room}, find the person whose drink is missing and provide the alternatives for they to choose.\\
 
 	If the robot comes to the place the person ordered and the person is not there, it can call that person loud, the person should respond (either sound or waving hand) and the robot must go to that place (check the person identity).
 

--- a/tests/StoringGroceries.tex
+++ b/tests/StoringGroceries.tex
@@ -1,4 +1,4 @@
-\section{Storing Groceries}
+\section{Storing Groceries [DSPL \& OPL]}
 
 The robot must help put the newly bought groceries in the right place.
 The owner of the robot will put the items on a table and the robot helps the owner by moving the groceries from a table to the right place in the cupboard.


### PR DESCRIPTION
Added Cocktail Party test
- Only SSPL
- Adapted from 2013 but targeting people finding and HRI
- Test time is 5 minutes
- score_sheets.tex updated
- Rulebook.tex updated
- Modified Storing Groceries to target DSPL and OPL only