### PR TITLE
EEGPSR scoresheet Shrink with example

### DIFF
--- a/scoresheets/EEGPSR.tex
+++ b/scoresheets/EEGPSR.tex
@@ -4,9 +4,9 @@ The maximum time for this test is 40 minutes.
 
 \begin{scorelist}
 	\scoreheading{Performance}
-	\scoreitem{15}{Understanding the command the $1^{st}$ attempt}
-    \scoreitem[-1]{5}{Each additional attempt (max 3)}
-	\scoreitem{15}{Solved random category / Each extra category (mix))}
+	\scoreitem[3]{15}{Understanding the command the $1^{st}$ attempt}
+    \scoreitem[3]{-5}{Each additional attempt (max 3)}
+	\scoreitem[3]{15}{Solved random category / Each extra category (mix)}
 	
 	\scoreheading{HRI}
 	\scoreitem{ 5}{Answering a predefined question / fetching orders after event detection}
@@ -15,14 +15,14 @@ The maximum time for this test is 40 minutes.
 
 	\scoreheading{Manipulation}
 	\scoreitem{ 5}{Grab/place an object}
-	\scoreitem{30}{Manipulation: two-handed, in narrow spaces, tiny/heavy/slippery objects}
+	\scoreitem{30}{Manipulation: two-handed, in narrow spaces*, tiny/heavy/slippery* objects}
 	\scoreitem{20}{Open/close a door/drawer*}
 	\scoreitem{50}{Pouring, pressing, uncapping, turning on/off, twisting}
 	
 	\scoreheading{Memory \& Awareness}
 	\scoreitem{10}{Detect an expected event (within a reasonable amount of time)*}
-	\scoreitem{20}{Detecting an unexpected event*}
-	\scoreitem{20}{Provide information about changes in the environment and/or given commands*}
+	\scoreitem{20}{Detect an unexpected event*}
+	\scoreitem{20}{Give information of environment changes/given commands*}
 
 	\scoreheading{Navigation}
 	\scoreitem{10}{Follow/guide operator (inside only)}
@@ -32,7 +32,7 @@ The maximum time for this test is 40 minutes.
 	\scoreitem{ 5}{Counting all objects, recognize known/alike object}
 	\scoreitem{15}{Counting objects in category / matching description*}
 	\scoreitem{30}{Describe unknown objects}
-	\scoreitem{30}{Find: from description*, occluded (>50\%)}
+	\scoreitem{30}{Find: from description*, occluded ($>50\%$)}
 	\scoreitem{50}{Find hidden objects, infer category from features}
 
 	\scoreheading{People, pose and activity recognition}

--- a/scoresheets/EEGPSR.tex
+++ b/scoresheets/EEGPSR.tex
@@ -1,64 +1,21 @@
-\ifEvaluationSheet{
-
-{\LARGE\textbf{Given commands:}}\vspace{4mm}
-
-\newcommand{\eegpsrsstrow}{
-	\multicolumn{6}{c}{\vspace{5mm}~}  \\ \hline
-	\multicolumn{6}{c}{\vspace{5mm}~}  \\ \hline
-	Category: 1 2 3 4 5 6 7 \vspace{8mm} &
-%	Restart? & Custom Operator? & Continue? & ASR attempts: 1 2 3 \\
-	{\footnotesize Restart?} & {\footnotesize Custom Operator?} & {\footnotesize MAN Bypass?} & {\footnotesize ASR Bypass?} & {\footnotesize ASR attempts:} $\Box \Box \Box$ \\
-}
-
-\begin{table}[h]
-\begin{tabularx}{\textwidth}{X r r r r r}
-	\textbf{\large Command 1:} & ~ & ~ & ~ & ~ & ~ \\ \hline
-	\eegpsrsstrow
-
-	\textbf{\large Command 1 $\cdot$ 2:} & ~ & ~ & ~ & ~ & ~ \\ \hline
-	\eegpsrsstrow
-	
-	\textbf{\large Command 1 $\cdot$ 2 $\cdot$ 3 :} & ~ & ~ & ~ & ~ & ~ \\ \hline
-	\eegpsrsstrow
-
-	\textbf{\large Command 1 $\cdot$ 2 $\cdot$ 3 :} & ~ & ~ & ~ & ~ & ~ \\ \hline
-	\eegpsrsstrow
-\end{tabularx}
-\end{table}
-\vspace*{\fill}
-
-\textbf{Remark: } Abilities marked with \textbf{*} are subjectively evaluated by  EC/TC members. Scoring is granted proportionally based on robot performance.
-
-\newpage
-}{}
-
 The maximum time for this test is 40 minutes.
 
 \begin{scorelist}
 	\scoreheading{Performance}
 	\scoreitem{15}{Understanding the command the $1^{st}$ attempt}
-        \scoreitem{10}{Understanding the command the $2^{nd}$ attempt}
-        \scoreitem{ 5}{Understanding the command the $3^{rd}$ attempt}
-	\scoreitem{15}{Random category successfully solved}
-	\scoreitem{20}{Mixing categories (bonus for each extra category)}
+    \scoreitem[-1]{5}{Each additional attempt (max 3)}
+	\scoreitem{15}{Solved random category / Each extra category (mix))}
 	
 	\scoreheading{HRI}
-	\scoreitem{ 5}{Answering a predefined question}
-	\scoreitem{10}{Ask for missing information}
-	\scoreitem{ 5}{Ask for command after detecting an event}
-	\scoreitem{10}{Explain in detail why the robot could not accomplish a task *}
+	\scoreitem{ 5}{Answering a predefined question / fetching orders after event detection}
+	\scoreitem{10}{Missing information retrieval / Providing explanations}
 	\scoreitem{20}{Natural handover (give or take)}
 
 	\scoreheading{Manipulation}
 	\scoreitem{ 5}{Grab/place an object}
-	\scoreitem{15}{Grab/place a stacked object}
-	\scoreitem{30}{Manipulation in narrow spaces}
-	\scoreitem{50}{Open/close a bottle/can *}
+	\scoreitem{30}{Manipulation: two-handed, in narrow spaces, tiny/heavy/slippery objects}
 	\scoreitem{20}{Open/close a door/drawer *}
-	\scoreitem{30}{Manipulation of buttons/levers/panels}
-	\scoreitem{30}{Manipulation of tiny/heavy/slippery objects}
-	\scoreitem{50}{Pour into a bowl *}
-	\scoreitem{30}{Two-handed manipulation *}
+	\scoreitem{50}{Pouring, pressing, uncapping, turning on/off, twisting}
 	
 	\scoreheading{Memory \& Awareness}
 	\scoreitem{10}{Detect an expected event (within a reasonable amount of time) *}
@@ -66,28 +23,21 @@ The maximum time for this test is 40 minutes.
 	\scoreitem{20}{Provide information about changes in the environment and/or given commands*}
 
 	\scoreheading{Navigation}
-	\scoreitem{20}{Follow operator until stopped}
-	\scoreitem{20}{Guide a human to location without loosing him or colliding}
+	\scoreitem{10}{Follow/guide operator (inside only)}
+	\scoreitem{15}{Follow/guide operator (outside)}
 	
 	\scoreheading{Object recognition}
-	\scoreitem{10}{Counting overall objects}
-	\scoreitem{30}{Counting objects in category}
-	\scoreitem{50}{Counting objects matching description *}
-	\scoreitem{30}{Describing an unknown object}
-	\scoreitem{30}{Find (and grasp) an object from a description *}
-	\scoreitem{30}{Find occluded object (>50\% occlusion)}
-	\scoreitem{50}{Find hidden object (100\% occlusion)}
-	\scoreitem{50}{Infer unknown object's class (category) from features}
-	\scoreitem{15}{Recognize alike object}
-	\scoreitem{ 5}{Recognize known object}
+	\scoreitem{ 5}{Counting all objects, recognize known/alike object}
+	\scoreitem{15}{Counting objects in category / matching description*}
+	\scoreitem{30}{Describe unknown objects}
+	\scoreitem{30}{Find: from description*, occluded (>50\%)}
+	\scoreitem{50}{Find hidden objects, infer category from features}
 
 	\scoreheading{People, pose and activity recognition}
-	\scoreitem{15}{Detect a calling/waving person}
-	\scoreitem{15}{Find a person in a given room}
-	\scoreitem{15}{Recognize a newly learned face correctly}
-	\scoreitem{20}{State the gender of a person}
+	\scoreitem{15}{Gesture detection}
+	\scoreitem{15}{Finding or recognizing people}
+	\scoreitem{20}{Person's geneder/pose* recognition}
 	\scoreitem{15}{State the number of people in a group}
-	\scoreitem{20}{State the pose of a person *}
 
 	\setTotalScore{0}
 \end{scorelist}

--- a/scoresheets/EEGPSR.tex
+++ b/scoresheets/EEGPSR.tex
@@ -1,5 +1,7 @@
 The maximum time for this test is 40 minutes.
 
+{\footnotesize
+
 \begin{scorelist}
 	\scoreheading{Performance}
 	\scoreitem{15}{Understanding the command the $1^{st}$ attempt}
@@ -14,11 +16,11 @@ The maximum time for this test is 40 minutes.
 	\scoreheading{Manipulation}
 	\scoreitem{ 5}{Grab/place an object}
 	\scoreitem{30}{Manipulation: two-handed, in narrow spaces, tiny/heavy/slippery objects}
-	\scoreitem{20}{Open/close a door/drawer *}
+	\scoreitem{20}{Open/close a door/drawer*}
 	\scoreitem{50}{Pouring, pressing, uncapping, turning on/off, twisting}
 	
 	\scoreheading{Memory \& Awareness}
-	\scoreitem{10}{Detect an expected event (within a reasonable amount of time) *}
+	\scoreitem{10}{Detect an expected event (within a reasonable amount of time)*}
 	\scoreitem{20}{Detecting an unexpected event*}
 	\scoreitem{20}{Provide information about changes in the environment and/or given commands*}
 
@@ -39,9 +41,9 @@ The maximum time for this test is 40 minutes.
 	\scoreitem{20}{Person's geneder/pose* recognition}
 	\scoreitem{15}{State the number of people in a group}
 
-	\setTotalScore{0}
+	\setTotalScore{500}
 \end{scorelist}
-
+}
 
 % Local Variables:
 % TeX-master: "Rulebook"

--- a/tests/EEGPSR_appendix.tex
+++ b/tests/EEGPSR_appendix.tex
@@ -278,3 +278,52 @@ Tasks from this category are much alike the ones in GPSR (see \refsec{chap:gpsr-
 	\item Take the chips from the counter, find a person in the bedroom, and go to the entrance.
 \end{itemize}
 
+
+
+\section{Scoring}
+The EEGPSR scoresheet is not straight-forward to understand, for there are too many possibilities to be listed and they would be hard to find. In consequence, this section explains how scoring is performed in EEGPSR by providing an example.
+
+% \subsection{Round 1}
+Robot Rosie of enters the arena and awaits for a command. Two hours before the test, team Jetsons requested the referee to give Rosie a command mixing Categories I and II, and V. The following (random) command is given:
+
+\begin{itemize}
+	\item[--] \textit{Bring some food to Elroy.}
+\end{itemize}
+
+As Rosie has no idea which kind of food she should deliver to Elroy nor where he is, she asks for the missing information:
+
+\begin{itemize}
+	\item[--] \texttt{Where can I find Elroy?}
+	\item[--] \textit{Elroy is at the bed.}
+	\item[--] \texttt{Which kind of food should I give to him?}
+	\item[--] \textit{Some Space O's in a bowl.}
+\end{itemize}
+
+After answering Rosie's questions the referee scores 25 points to the Jetsons; fifteen for understanding the command at the very first attempt, and only ten for retrieving missing information even though the Robot asked two questions. This is because a robot can score only once per demonstrated ability and Rosie has proven it can request missing information. Rosie will score no more points for making questions.
+
+Continuing with the example; Rossie navigates then to the kitchen and starts looking for the \textit{bowl} and \textit{Space O's cereals}. Since Rosie is a nice maid, she places the bowl in a tray she just put on the table. However, the cereals are nowhere within sight or where they should be, so Rosie looks deeper for them and opens one of the doors of the cupboard, finding finally the Space O's. Rosie takes the box, drives back to the table and pours the cereals into the bowl, spilling some of them in the tray, and leaving the box on the table.
+
+In the meanwhile, the referee gave Rossie:
+\begin{itemize}
+	\item[30pts] For placing the tray on the table (2-handed manipulation).
+	\item[20pts] For manipulating the the bowl.
+	\item[20pts] For opening the cupboard's door.
+	\item[50pts] For finding the Space O's cereals (hidden object).
+	\item[ 5pts] For picking the Space O's cereals from the cupboard.
+	\item[ 5pts] For safely placing the Space O's cereals on the table.
+	\item[25pts] For pouring the Space O's cereals into the bowl but spilling.
+\end{itemize}
+
+Please note that no points are given for recognizing the tray or placing it on the table, as well as no bonus is given for placing the bowl on top of the tray as using the tray was not requested; however, the referee gives 20 points to Rosie for handling (pick and place) the bowl as its round shape makes it hard to manipulate. For pouring the cereals, Rosie could have achieved up to 50 points, but she spilled the content so only partial scoring is given. 
+
+Continuing with the example; Rosie announces that the bowl is harder than the tray for her to transport, so she will deliver the bowl using the tray. After successfully picking up the tray, Rossie heads towards Elroy's room, where she finds the boy who takes the bowl from the tray. After completing the command, Rosie goes back to the start point, and finishing the round. Yet she explains to the operator what she did, making emphasis in the fact that the Space O's were not on its place, but hidden.
+
+In the meanwhile, the referee gave Rossie:
+\begin{itemize}
+	\item[30pts] For moving the tray (2-handed manipulation) as it was reasonable and required by the robot.
+	\item[30pts] For accomplishing a command involving 3 categories ($base + 2\times15$).
+\end{itemize}
+
+Since finding Elroy at the bed presents no difficulty at all, and it was the boy who took the bowl from the tray (i.e. no handover), no additional points were scored. Furthermore, no additional score is given for remembering changes in the environment since neither the robot was requested to provide any further explanation, nor a command requiring to use that information was given. \\
+
+\textbf{$1^{st}$ Round score:} 240 points.


### PR DESCRIPTION
EEGPSR test
- Added scoring example in appendix.
- Reduced Follow/guide score (now matches help-me-carry).
- Known and alike objects grant now the same amount of points (scoring matches Storing Groceries).
- Reduced scoring for counting/recognizing objects accordingly with other tests.
- Grouped features (it is expected the referee mark and score for each one solved instead of consider the group as one).
- Reduced bonus for category mixing to group with random category.
- Synthesized some scoresheet entries.
- Addressed #260 #236