### PR TITLE
EEGPSR scoresheet Shrink with example

### DIFF
--- a/scoresheets/EEGPSR.tex
+++ b/scoresheets/EEGPSR.tex
@@ -9,8 +9,8 @@ The maximum time for this test is 40 minutes.
 	\scoreitem[3]{15}{Solved random category / Each extra category (mix)}
 	
 	\scoreheading{HRI}
-	\scoreitem{ 5}{Answering a predefined question / fetching orders after event detection}
-	\scoreitem{10}{Missing information retrieval / Providing explanations}
+	\scoreitem{ 5}{Answer a predefined question / fetch orders after event detection}
+	\scoreitem{10}{Missing information retrieval / Provide explanations on operator's request}
 	\scoreitem{20}{Natural handover (give or take)}
 
 	\scoreheading{Manipulation}
@@ -21,8 +21,8 @@ The maximum time for this test is 40 minutes.
 	
 	\scoreheading{Memory \& Awareness}
 	\scoreitem{10}{Detect an expected event (within a reasonable amount of time)*}
-	\scoreitem{20}{Detect an unexpected event*}
-	\scoreitem{20}{Give information of environment changes/given commands*}
+	\scoreitem{20}{Detect an unexpected event*/Provide sucessful alternate solution*}
+	\scoreitem{20}{Give/use information of the environment/previous commands*}
 
 	\scoreheading{Navigation}
 	\scoreitem{10}{Follow/guide operator (inside only)}

--- a/scoresheets/EEGPSR.tex
+++ b/scoresheets/EEGPSR.tex
@@ -1,12 +1,13 @@
-The maximum time for this test is 40 minutes.
+The maximum time for this test is 40 minutes.\\
+{\scriptsize \textbf{Note 1:} Related abilities with similar score are packed together for brevity. Rreferees must mark them and score accordingly.}\\
+{\scriptsize \textbf{Note 2:} Abilities marked with * score \textit{at most} the suggested points based on the difficulty and performance (following TC criteria).}
 
 {\footnotesize
 
 \begin{scorelist}
-	\scoreheading{Performance}
-	\scoreitem[3]{15}{Understanding the command the $1^{st}$ attempt}
-    \scoreitem[3]{-5}{Each additional attempt (max 3)}
-	\scoreitem[3]{15}{Solved random category / Each extra category (mix)}
+	\scoreheading{Command retrieval \& Categories}
+	\scoreitem[3]{15}{Understand a command in the $1^{st}$ attempt (score per generated command)}
+	\scoreitem{15}{Solved random category / Each extra category (mix)}
 	
 	\scoreheading{HRI}
 	\scoreitem{ 5}{Answer a predefined question / fetch orders after event detection}
@@ -29,21 +30,22 @@ The maximum time for this test is 40 minutes.
 	\scoreitem{15}{Follow/guide operator (outside)}
 	
 	\scoreheading{Object recognition}
-	\scoreitem{ 5}{Counting all objects, recognize known/alike object}
-	\scoreitem{15}{Counting objects in category / matching description*}
+	\scoreitem{ 5}{Count all objects, recognize known/alike object}
+	\scoreitem{15}{Count objects in category / matching description*}
 	\scoreitem{30}{Describe unknown objects}
 	\scoreitem{30}{Find: from description*, occluded ($>50\%$)}
 	\scoreitem{50}{Find hidden objects, infer category from features}
 
 	\scoreheading{People, pose and activity recognition}
 	\scoreitem{15}{Gesture detection}
-	\scoreitem{15}{Finding or recognizing people}
+	\scoreitem{15}{Find or recognizing people}
 	\scoreitem{20}{Person's geneder/pose* recognition}
 	\scoreitem{15}{State the number of people in a group}
 
 	\setTotalScore{500}
 \end{scorelist}
 }
+
 
 % Local Variables:
 % TeX-master: "Rulebook"

--- a/scoresheets/EEGPSR.tex
+++ b/scoresheets/EEGPSR.tex
@@ -4,9 +4,9 @@ The maximum time for this test is 40 minutes.
 
 \begin{scorelist}
 	\scoreheading{Performance}
-	\scoreitem{15}{Understanding the command the $1^{st}$ attempt}
-    \scoreitem[-1]{5}{Each additional attempt (max 3)}
-	\scoreitem{15}{Solved random category / Each extra category (mix))}
+	\scoreitem[3]{15}{Understanding the command the $1^{st}$ attempt}
+    \scoreitem[3]{-5}{Each additional attempt (max 3)}
+	\scoreitem[3]{15}{Solved random category / Each extra category (mix)}
 	
 	\scoreheading{HRI}
 	\scoreitem{ 5}{Answering a predefined question / fetching orders after event detection}
@@ -15,14 +15,14 @@ The maximum time for this test is 40 minutes.
 
 	\scoreheading{Manipulation}
 	\scoreitem{ 5}{Grab/place an object}
-	\scoreitem{30}{Manipulation: two-handed, in narrow spaces, tiny/heavy/slippery objects}
+	\scoreitem{30}{Manipulation: two-handed, in narrow spaces*, tiny/heavy/slippery* objects}
 	\scoreitem{20}{Open/close a door/drawer*}
 	\scoreitem{50}{Pouring, pressing, uncapping, turning on/off, twisting}
 	
 	\scoreheading{Memory \& Awareness}
 	\scoreitem{10}{Detect an expected event (within a reasonable amount of time)*}
-	\scoreitem{20}{Detecting an unexpected event*}
-	\scoreitem{20}{Provide information about changes in the environment and/or given commands*}
+	\scoreitem{20}{Detect an unexpected event*}
+	\scoreitem{20}{Give information of environment changes/given commands*}
 
 	\scoreheading{Navigation}
 	\scoreitem{10}{Follow/guide operator (inside only)}
@@ -32,7 +32,7 @@ The maximum time for this test is 40 minutes.
 	\scoreitem{ 5}{Counting all objects, recognize known/alike object}
 	\scoreitem{15}{Counting objects in category / matching description*}
 	\scoreitem{30}{Describe unknown objects}
-	\scoreitem{30}{Find: from description*, occluded (>50\%)}
+	\scoreitem{30}{Find: from description*, occluded ($>50\%$)}
 	\scoreitem{50}{Find hidden objects, infer category from features}
 
 	\scoreheading{People, pose and activity recognition}

--- a/scoresheets/EEGPSR.tex
+++ b/scoresheets/EEGPSR.tex
@@ -1,64 +1,21 @@
-\ifEvaluationSheet{
-
-{\LARGE\textbf{Given commands:}}\vspace{4mm}
-
-\newcommand{\eegpsrsstrow}{
-	\multicolumn{6}{c}{\vspace{5mm}~}  \\ \hline
-	\multicolumn{6}{c}{\vspace{5mm}~}  \\ \hline
-	Category: 1 2 3 4 5 6 7 \vspace{8mm} &
-%	Restart? & Custom Operator? & Continue? & ASR attempts: 1 2 3 \\
-	{\footnotesize Restart?} & {\footnotesize Custom Operator?} & {\footnotesize MAN Bypass?} & {\footnotesize ASR Bypass?} & {\footnotesize ASR attempts:} $\Box \Box \Box$ \\
-}
-
-\begin{table}[h]
-\begin{tabularx}{\textwidth}{X r r r r r}
-	\textbf{\large Command 1:} & ~ & ~ & ~ & ~ & ~ \\ \hline
-	\eegpsrsstrow
-
-	\textbf{\large Command 1 $\cdot$ 2:} & ~ & ~ & ~ & ~ & ~ \\ \hline
-	\eegpsrsstrow
-	
-	\textbf{\large Command 1 $\cdot$ 2 $\cdot$ 3 :} & ~ & ~ & ~ & ~ & ~ \\ \hline
-	\eegpsrsstrow
-
-	\textbf{\large Command 1 $\cdot$ 2 $\cdot$ 3 :} & ~ & ~ & ~ & ~ & ~ \\ \hline
-	\eegpsrsstrow
-\end{tabularx}
-\end{table}
-\vspace*{\fill}
-
-\textbf{Remark: } Abilities marked with \textbf{*} are subjectively evaluated by  EC/TC members. Scoring is granted proportionally based on robot performance.
-
-\newpage
-}{}
-
 The maximum time for this test is 40 minutes.
 
 \begin{scorelist}
 	\scoreheading{Performance}
 	\scoreitem{15}{Understanding the command the $1^{st}$ attempt}
-        \scoreitem{10}{Understanding the command the $2^{nd}$ attempt}
-        \scoreitem{ 5}{Understanding the command the $3^{rd}$ attempt}
-	\scoreitem{15}{Random category successfully solved}
-	\scoreitem{20}{Mixing categories (bonus for each extra category)}
+    \scoreitem[-1]{5}{Each additional attempt (max 3)}
+	\scoreitem{15}{Solved random category / Each extra category (mix))}
 	
 	\scoreheading{HRI}
-	\scoreitem{ 5}{Answering a predefined question}
-	\scoreitem{10}{Ask for missing information}
-	\scoreitem{ 5}{Ask for command after detecting an event}
-	\scoreitem{10}{Explain in detail why the robot could not accomplish a task *}
+	\scoreitem{ 5}{Answering a predefined question / fetching orders after event detection}
+	\scoreitem{10}{Missing information retrieval / Providing explanations}
 	\scoreitem{20}{Natural handover (give or take)}
 
 	\scoreheading{Manipulation}
 	\scoreitem{ 5}{Grab/place an object}
-	\scoreitem{15}{Grab/place a stacked object}
-	\scoreitem{30}{Manipulation in narrow spaces}
-	\scoreitem{50}{Open/close a bottle/can *}
+	\scoreitem{30}{Manipulation: two-handed, in narrow spaces, tiny/heavy/slippery objects}
 	\scoreitem{20}{Open/close a door/drawer *}
-	\scoreitem{30}{Manipulation of buttons/levers/panels}
-	\scoreitem{30}{Manipulation of tiny/heavy/slippery objects}
-	\scoreitem{50}{Pour into a bowl *}
-	\scoreitem{30}{Two-handed manipulation *}
+	\scoreitem{50}{Pouring, pressing, uncapping, turning on/off, twisting}
 	
 	\scoreheading{Memory \& Awareness}
 	\scoreitem{10}{Detect an expected event (within a reasonable amount of time) *}
@@ -66,28 +23,21 @@ The maximum time for this test is 40 minutes.
 	\scoreitem{20}{Provide information about changes in the environment and/or given commands*}
 
 	\scoreheading{Navigation}
-	\scoreitem{20}{Follow operator until stopped}
-	\scoreitem{20}{Guide a human to location without loosing him or colliding}
+	\scoreitem{10}{Follow/guide operator (inside only)}
+	\scoreitem{15}{Follow/guide operator (outside)}
 	
 	\scoreheading{Object recognition}
-	\scoreitem{10}{Counting overall objects}
-	\scoreitem{30}{Counting objects in category}
-	\scoreitem{50}{Counting objects matching description *}
-	\scoreitem{30}{Describing an unknown object}
-	\scoreitem{30}{Find (and grasp) an object from a description *}
-	\scoreitem{30}{Find occluded object (>50\% occlusion)}
-	\scoreitem{50}{Find hidden object (100\% occlusion)}
-	\scoreitem{50}{Infer unknown object's class (category) from features}
-	\scoreitem{15}{Recognize alike object}
-	\scoreitem{ 5}{Recognize known object}
+	\scoreitem{ 5}{Counting all objects, recognize known/alike object}
+	\scoreitem{15}{Counting objects in category / matching description*}
+	\scoreitem{30}{Describe unknown objects}
+	\scoreitem{30}{Find: from description*, occluded (>50\%)}
+	\scoreitem{50}{Find hidden objects, infer category from features}
 
 	\scoreheading{People, pose and activity recognition}
-	\scoreitem{15}{Detect a calling/waving person}
-	\scoreitem{15}{Find a person in a given room}
-	\scoreitem{15}{Recognize a newly learned face correctly}
-	\scoreitem{20}{State the gender of a person}
+	\scoreitem{15}{Gesture detection}
+	\scoreitem{15}{Finding or recognizing people}
+	\scoreitem{20}{Person's geneder/pose* recognition}
 	\scoreitem{15}{State the number of people in a group}
-	\scoreitem{20}{State the pose of a person *}
 
 	\setTotalScore{0}
 \end{scorelist}

--- a/scoresheets/EEGPSR.tex
+++ b/scoresheets/EEGPSR.tex
@@ -1,5 +1,7 @@
 The maximum time for this test is 40 minutes.
 
+{\footnotesize
+
 \begin{scorelist}
 	\scoreheading{Performance}
 	\scoreitem{15}{Understanding the command the $1^{st}$ attempt}
@@ -14,11 +16,11 @@ The maximum time for this test is 40 minutes.
 	\scoreheading{Manipulation}
 	\scoreitem{ 5}{Grab/place an object}
 	\scoreitem{30}{Manipulation: two-handed, in narrow spaces, tiny/heavy/slippery objects}
-	\scoreitem{20}{Open/close a door/drawer *}
+	\scoreitem{20}{Open/close a door/drawer*}
 	\scoreitem{50}{Pouring, pressing, uncapping, turning on/off, twisting}
 	
 	\scoreheading{Memory \& Awareness}
-	\scoreitem{10}{Detect an expected event (within a reasonable amount of time) *}
+	\scoreitem{10}{Detect an expected event (within a reasonable amount of time)*}
 	\scoreitem{20}{Detecting an unexpected event*}
 	\scoreitem{20}{Provide information about changes in the environment and/or given commands*}
 
@@ -39,9 +41,9 @@ The maximum time for this test is 40 minutes.
 	\scoreitem{20}{Person's geneder/pose* recognition}
 	\scoreitem{15}{State the number of people in a group}
 
-	\setTotalScore{0}
+	\setTotalScore{500}
 \end{scorelist}
-
+}
 
 % Local Variables:
 % TeX-master: "Rulebook"

--- a/tests/EEGPSR.tex
+++ b/tests/EEGPSR.tex
@@ -86,7 +86,7 @@ This test particularly focuses on the following aspects:
 
 	\item \textbf{Referees:} Since the score system in this test involves a subjective evaluation of the robot's behavior, the referees are EC/TC members. One referee is assigned to each team to judge performance, to measure the time for working on a command, and to keep track of the overall operating time of the robot. \\
 
-	\item \textbf{Category selection:} For every of the three commands given to the robot, the team chooses the desired command category. Please do note that points for showing an ability can only be scored once, as also detailed in the next point.\\
+	\item \textbf{Category selection:} For every of the three commands given to the robot, the team chooses the desired command category. Please do note that points for showing an ability can only be scored once.\\
 
 	\item \textbf{Operator:}
 	\begin{itemize}

--- a/tests/EEGPSR_appendix.tex
+++ b/tests/EEGPSR_appendix.tex
@@ -278,3 +278,52 @@ Tasks from this category are much alike the ones in GPSR (see \refsec{chap:gpsr-
 	\item Take the chips from the counter, find a person in the bedroom, and go to the entrance.
 \end{itemize}
 
+
+
+\section{Scoring}
+The EEGPSR scoresheet is not straight-forward to understand, for there are too many possibilities to be listed and they would be hard to find. In consequence, this section explains how scoring is performed in EEGPSR by providing an example.
+
+% \subsection{Round 1}
+Robot Rosie of enters the arena and awaits for a command. Two hours before the test, team Jetsons requested the referee to give Rosie a command mixing Categories I and II, and V. The following (random) command is given:
+
+\begin{itemize}
+	\item[--] \textit{Bring some food to Elroy.}
+\end{itemize}
+
+As Rosie has no idea which kind of food she should deliver to Elroy nor where he is, she asks for the missing information:
+
+\begin{itemize}
+	\item[--] \texttt{Where can I find Elroy?}
+	\item[--] \textit{Elroy is at the bed.}
+	\item[--] \texttt{Which kind of food should I give to him?}
+	\item[--] \textit{Some Space O's in a bowl.}
+\end{itemize}
+
+After answering Rosie's questions the referee scores 25 points to the Jetsons; fifteen for understanding the command at the very first attempt, and only ten for retrieving missing information even though the Robot asked two questions. This is because a robot can score only once per demonstrated ability and Rosie has proven it can request missing information. Rosie will score no more points for making questions.
+
+Continuing with the example; Rossie navigates then to the kitchen and starts looking for the \textit{bowl} and \textit{Space O's cereals}. Since Rosie is a nice maid, she places the bowl in a tray she just put on the table. However, the cereals are nowhere within sight or where they should be, so Rosie looks deeper for them and opens one of the doors of the cupboard, finding finally the Space O's. Rosie takes the box, drives back to the table and pours the cereals into the bowl, spilling some of them in the tray, and leaving the box on the table.
+
+In the meanwhile, the referee gave Rossie:
+\begin{itemize}
+	\item[30pts] For placing the tray on the table (2-handed manipulation).
+	\item[20pts] For manipulating the the bowl.
+	\item[20pts] For opening the cupboard's door.
+	\item[50pts] For finding the Space O's cereals (hidden object).
+	\item[ 5pts] For picking the Space O's cereals from the cupboard.
+	\item[ 5pts] For safely placing the Space O's cereals on the table.
+	\item[25pts] For pouring the Space O's cereals into the bowl but spilling.
+\end{itemize}
+
+Please note that no points are given for recognizing the tray or placing it on the table, as well as no bonus is given for placing the bowl on top of the tray as using the tray was not requested; however, the referee gives 20 points to Rosie for handling (pick and place) the bowl as its round shape makes it hard to manipulate. For pouring the cereals, Rosie could have achieved up to 50 points, but she spilled the content so only partial scoring is given. 
+
+Continuing with the example; Rosie announces that the bowl is harder than the tray for her to transport, so she will deliver the bowl using the tray. After successfully picking up the tray, Rossie heads towards Elroy's room, where she finds the boy who takes the bowl from the tray. After completing the command, Rosie goes back to the start point, and finishing the round. Yet she explains to the operator what she did, making emphasis in the fact that the Space O's were not on its place, but hidden.
+
+In the meanwhile, the referee gave Rossie:
+\begin{itemize}
+	\item[30pts] For moving the tray (2-handed manipulation) as it was reasonable and required by the robot.
+	\item[30pts] For accomplishing a command involving 3 categories ($base + 2\times15$).
+\end{itemize}
+
+Since finding Elroy at the bed presents no difficulty at all, and it was the boy who took the bowl from the tray (i.e. no handover), no additional points were scored. Furthermore, no additional score is given for remembering changes in the environment since neither the robot was requested to provide any further explanation, nor a command requiring to use that information was given. \\
+
+\textbf{$1^{st}$ Round score:} 240 points.

--- a/tests/EEGPSR_appendix.tex
+++ b/tests/EEGPSR_appendix.tex
@@ -283,7 +283,7 @@ Tasks from this category are much alike the ones in GPSR (see \refsec{chap:gpsr-
 \section{Scoring}
 The EEGPSR scoresheet is not straight-forward to understand, for there are too many possibilities to be listed and they would be hard to find. In consequence, this section explains how scoring is performed in EEGPSR by providing an example.
 
-% \subsection{Round 1}
+\subsection{Round 1}
 Robot Rosie of enters the arena and awaits for a command. Two hours before the test, team Jetsons requested the referee to give Rosie a command mixing Categories I and II, and V. The following (random) command is given:
 
 \begin{itemize}
@@ -327,3 +327,42 @@ In the meanwhile, the referee gave Rossie:
 Since finding Elroy at the bed presents no difficulty at all, and it was the boy who took the bowl from the tray (i.e. no handover), no additional points were scored. Furthermore, no additional score is given for remembering changes in the environment since neither the robot was requested to provide any further explanation, nor a command requiring to use that information was given. \\
 
 \textbf{$1^{st}$ Round score:} 240 points.
+
+\subsection{Round 2}
+Is witing inside the arena for a command. Two hours before the test, team Jetsons requested the referee to give Rosie a command mixing Categories IV and VI, and VII. The following (random) command is given:
+
+\begin{itemize}
+	\item[--] \textit{Ask the white-haired person wearing a pink blouse in the dining room where is Elroy and deliver him the Space O's.}
+\end{itemize}
+
+After confirming the command, Rosie heads towards the kitchen table and grasps from there the Space O's box she just poured in the past round. Then she goes to the dining room where George is having breakfast. The robot speaks out loud that there are no people wearing pink in the dining room and that she will try in the living room before asking where to search.
+
+The referee has scored Rosie as follows:
+\begin{itemize}
+	\item[15pts] For $1^{st}$ attempt command retrieval.
+	\item[20pts] For remembering the last location of the \textit{Space O's} (kitchen table).
+	\item[20pts] For detecting the target is not at the dining room and proposing an alternate, reasonable, working solution to the problem (search living room).
+\end{itemize}
+
+Going back to the example; Rosie arrives to the living room where Judy and Jane watch TV. Judy is a white-dyed teenager wearing pink, while Jane is a blond woman dressed in purple. Confused, Rossie approaches Jane and asks where to find Elroy:
+\begin{itemize}
+	\item[Rosie:] \texttt{Where can I find Elroy?}
+	\item[Jane: ] \textit{Elroy is at school.}
+	\item[Rosie:] \texttt{I can't reach there. What should I do now?}
+	\item[Judy: ] \textit{Could you please give me the Space O's?}
+	\item[Rosie:] \texttt{Here you are.}
+\end{itemize}
+
+Finally, Judy goes back with the operator and explains that it delivered the Space O's to the person upon request because Elroy was not at home, so it was impossible to deliver them. The round is over and the operator scores as follows:
+\begin{itemize}
+	\item[ 0pts] For finding the described person, since Judy was described but the robot approached Jane.
+	\item[20pts] For realizing the action was impossible to be carried out (unexpected event).
+	\item[10pts] For fetching for command from Judy (action after event detection).
+	\item[20pts] For realizing it was on possession of the object and proceed to immediate deliver (use of environment information to accomplish command).
+	\item[20pts] Space O's natural handover.
+	\item[30pts] For accomplishing a command involving 3 categories ($base + 2\times15$).
+\end{itemize}
+
+Please notice that, although it may seem otherwise, the rule of not scoring twice for the same ability is preserved. First, the robot uses its memory to recall where the cereals were left; while latter it uses environmental information (i.e. the fact that is holding the Space O's) to accomplish the command. The same applies to event and error handling. The robot first scores for controlling erroneous information (the people was not where it was supposed to) and then scores for reacting to a completely unexpected event for which there is no reasonable solution; and yet is able to react to a command from a third source.
+
+\textbf{$2^{nd}$ Round score:} 165 points. \textbf{Total score:} 395 points.

--- a/tests/EEGPSR_appendix.tex
+++ b/tests/EEGPSR_appendix.tex
@@ -27,7 +27,7 @@ When a robot has partially understood the command, it is allowed to ask the oper
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Categories explained}
 \label{sec:eegpsr-categories-explained}
-This section explain each of the categories of the test and provides examples on how the abilities are scored.
+This section explain each of the categories of the test and provides examples on the given commands and expected abilities.
 
 It is important to remark that there is no script or predefined way to solve the tasks, being most of them of ambiguous nature. It is up to the team to choose how to solve each tasks accordingly with the robot's capabilities.
 
@@ -283,7 +283,11 @@ Tasks from this category are much alike the ones in GPSR (see \refsec{chap:gpsr-
 \section{Scoring}
 The EEGPSR scoresheet is not straight-forward to understand, for there are too many possibilities to be listed and they would be hard to find. In consequence, this section explains how scoring is performed in EEGPSR by providing an example.
 
-\subsection{Round 1}
+It is important to remark that in EEGPSR, that points for each demonstrated ability be scored only once. Exception to this rule are Speech Recognition, Natural Language Understanding, and Error and Event Handling; key abilities that are core of this test. being often considered. The referees will often consider the best execution of a given demonstrated ability (e.g. object recognition) as long as the performance looks consistent and not simply a lucky strike.
+
+Another important remark is that referees can grant partial points for a demonstrated ability regarding the performance of the robot (e.g. precision, accuracy, speed, consistency) and the difficulty of the task. In the same way, referees can forfeit points if the task execution looks tweaked or over scripted, as well in those cases in which the robot is performing actions to harvest points or exploiting the rules instead of trying to efficiently solve the task.
+
+\subsection{Example round 1}
 Robot Rosie enters the arena and awaits for a command. Two hours before the test, team Jetsons requested the referee to give Rosie a command mixing Categories I and II, and V. The following (random) command is given:
 
 \begin{itemize}
@@ -328,7 +332,7 @@ Since finding Elroy at the bed presents no difficulty at all, and it was the boy
 
 \textbf{$1^{st}$ Round score:} 240 points.
 
-\subsection{Round 2}
+\subsection{Example round 2}
 The robot is waiting inside the arena for a command. Two hours before the test, team Jetsons requested the referee to give Rosie a command mixing Categories IV and VI, and VII. The following (random) command is given:
 
 \begin{itemize}

--- a/tests/EEGPSR_appendix.tex
+++ b/tests/EEGPSR_appendix.tex
@@ -284,7 +284,7 @@ Tasks from this category are much alike the ones in GPSR (see \refsec{chap:gpsr-
 The EEGPSR scoresheet is not straight-forward to understand, for there are too many possibilities to be listed and they would be hard to find. In consequence, this section explains how scoring is performed in EEGPSR by providing an example.
 
 \subsection{Round 1}
-Robot Rosie of enters the arena and awaits for a command. Two hours before the test, team Jetsons requested the referee to give Rosie a command mixing Categories I and II, and V. The following (random) command is given:
+Robot Rosie enters the arena and awaits for a command. Two hours before the test, team Jetsons requested the referee to give Rosie a command mixing Categories I and II, and V. The following (random) command is given:
 
 \begin{itemize}
 	\item[--] \textit{Bring some food to Elroy.}
@@ -301,9 +301,9 @@ As Rosie has no idea which kind of food she should deliver to Elroy nor where he
 
 After answering Rosie's questions the referee scores 25 points to the Jetsons; fifteen for understanding the command at the very first attempt, and only ten for retrieving missing information even though the Robot asked two questions. This is because a robot can score only once per demonstrated ability and Rosie has proven it can request missing information. Rosie will score no more points for making questions.
 
-Continuing with the example; Rossie navigates then to the kitchen and starts looking for the \textit{bowl} and \textit{Space O's cereals}. Since Rosie is a nice maid, she places the bowl in a tray she just put on the table. However, the cereals are nowhere within sight or where they should be, so Rosie looks deeper for them and opens one of the doors of the cupboard, finding finally the Space O's. Rosie takes the box, drives back to the table and pours the cereals into the bowl, spilling some of them in the tray, and leaving the box on the table.
+Continuing with the example; Rosie navigates then to the kitchen and starts looking for the \textit{bowl} and \textit{Space O's cereals}. Since Rosie is a nice maid, she places the bowl in a tray she just put on the table. However, the cereals are nowhere within sight or where they should be, so Rosie looks deeper for them and opens one of the doors of the cupboard, finding finally the Space O's. Rosie takes the box, drives back to the table and pours the cereals into the bowl, spilling some of them in the tray, and leaving the box on the table.
 
-In the meanwhile, the referee gave Rossie:
+In the meanwhile, the referee gave Rosie:
 \begin{itemize}
 	\item[30pts] For placing the tray on the table (2-handed manipulation).
 	\item[20pts] For manipulating the the bowl.
@@ -316,9 +316,9 @@ In the meanwhile, the referee gave Rossie:
 
 Please note that no points are given for recognizing the tray or placing it on the table, as well as no bonus is given for placing the bowl on top of the tray as using the tray was not requested; however, the referee gives 20 points to Rosie for handling (pick and place) the bowl as its round shape makes it hard to manipulate. For pouring the cereals, Rosie could have achieved up to 50 points, but she spilled the content so only partial scoring is given. 
 
-Continuing with the example; Rosie announces that the bowl is harder than the tray for her to transport, so she will deliver the bowl using the tray. After successfully picking up the tray, Rossie heads towards Elroy's room, where she finds the boy who takes the bowl from the tray. After completing the command, Rosie goes back to the start point, and finishing the round. Yet she explains to the operator what she did, making emphasis in the fact that the Space O's were not on its place, but hidden.
+Continuing with the example; Rosie announces that the bowl is harder than the tray for her to transport, so she will deliver the bowl using the tray. After successfully picking up the tray, Rosie heads towards Elroy's room, where she finds the boy who takes the bowl from the tray. After completing the command, Rosie goes back to the start point, and finishes the round. Yet she explains to the operator what she did, making emphasis in the fact that the Space O's were not on its place, but hidden.
 
-In the meanwhile, the referee gave Rossie:
+In the meanwhile, the referee gave Rosie:
 \begin{itemize}
 	\item[30pts] For moving the tray (2-handed manipulation) as it was reasonable and required by the robot.
 	\item[30pts] For accomplishing a command involving 3 categories ($base + 2\times15$).
@@ -329,7 +329,7 @@ Since finding Elroy at the bed presents no difficulty at all, and it was the boy
 \textbf{$1^{st}$ Round score:} 240 points.
 
 \subsection{Round 2}
-Is witing inside the arena for a command. Two hours before the test, team Jetsons requested the referee to give Rosie a command mixing Categories IV and VI, and VII. The following (random) command is given:
+The robot is waiting inside the arena for a command. Two hours before the test, team Jetsons requested the referee to give Rosie a command mixing Categories IV and VI, and VII. The following (random) command is given:
 
 \begin{itemize}
 	\item[--] \textit{Ask the white-haired person wearing a pink blouse in the dining room where is Elroy and deliver him the Space O's.}
@@ -344,7 +344,7 @@ The referee has scored Rosie as follows:
 	\item[20pts] For detecting the target is not at the dining room and proposing an alternate, reasonable, working solution to the problem (search living room).
 \end{itemize}
 
-Going back to the example; Rosie arrives to the living room where Judy and Jane watch TV. Judy is a white-dyed teenager wearing pink, while Jane is a blond woman dressed in purple. Confused, Rossie approaches Jane and asks where to find Elroy:
+Going back to the example; Rosie arrives to the living room where Judy and Jane watch TV. Judy is a white-dyed teenager wearing pink, while Jane is a blond woman dressed in purple. Confused, Rosie approaches Jane and asks where to find Elroy:
 \begin{itemize}
 	\item[Rosie:] \texttt{Where can I find Elroy?}
 	\item[Jane: ] \textit{Elroy is at school.}
@@ -353,16 +353,16 @@ Going back to the example; Rosie arrives to the living room where Judy and Jane 
 	\item[Rosie:] \texttt{Here you are.}
 \end{itemize}
 
-Finally, Judy goes back with the operator and explains that it delivered the Space O's to the person upon request because Elroy was not at home, so it was impossible to deliver them. The round is over and the operator scores as follows:
+Finally, Rosie goes back with the operator and explains that it delivered the Space O's to the person upon request because Elroy was not at home, so it was impossible to deliver them. The round is over and the operator scores as follows:
 \begin{itemize}
 	\item[ 0pts] For finding the described person, since Judy was described but the robot approached Jane.
-	\item[20pts] For realizing the action was impossible to be carried out (unexpected event).
+	\item[20pts] For realizing the action was impossible to be carried out.
 	\item[10pts] For fetching for command from Judy (action after event detection).
-	\item[20pts] For realizing it was on possession of the object and proceed to immediate deliver (use of environment information to accomplish command).
+	\item[20pts] For realizing it was in possession of the object and proceed to immediate deliver (use of environment information to accomplish command).
 	\item[20pts] Space O's natural handover.
 	\item[30pts] For accomplishing a command involving 3 categories ($base + 2\times15$).
 \end{itemize}
 
-Please notice that, although it may seem otherwise, the rule of not scoring twice for the same ability is preserved. First, the robot uses its memory to recall where the cereals were left; while latter it uses environmental information (i.e. the fact that is holding the Space O's) to accomplish the command. The same applies to event and error handling. The robot first scores for controlling erroneous information (the people was not where it was supposed to) and then scores for reacting to a completely unexpected event for which there is no reasonable solution; and yet is able to react to a command from a third source.
+Please notice that, although it may seem otherwise, the rule of not scoring twice for the same ability is preserved. First, the robot uses its memory to recall where the cereals were left; while latter it uses environmental information (i.e. the fact that is holding the Space O's) to accomplish the command. The same applies to event and error handling. The robot first scores for controlling erroneous information that can be controlled (the people was not where it was supposed to) and scores for controlling a situation for which there is no reasonable solution, also able to react to a command from a third source.
 
 \textbf{$2^{nd}$ Round score:} 165 points. \textbf{Total score:} 395 points.


### PR DESCRIPTION
EEGPSR test
- Added scoring example in appendix.
- Reduced Follow/guide score (now matches help-me-carry).
- Known and alike objects grant now the same amount of points (scoring matches Storing Groceries).
- Reduced scoring for counting/recognizing objects accordingly with other tests.
- Grouped features (it is expected the referee mark and score for each one solved instead of consider the group as one).
- Reduced bonus for category mixing to group with random category.
- Synthesized some scoresheet entries.
- Addressed #260 #236