### PR TITLE
External Computing explicitly allows own software

### DIFF
--- a/general_rules/ExternalComputing.tex
+++ b/general_rules/ExternalComputing.tex
@@ -4,9 +4,12 @@ Robots are allowed to use some form of external computing, for example in the fo
 \begin{enumerate}
 	\item \textbf{Definition:} Computing resources that are not physical part of the robot are \iterm{external computing resources}. 
 	\item \textbf{Inspection:} In general, external computers are not allowed unless explained to and allowed by the \iaterm{Technical Committee}{TC}.
-	  A team must announce to the TC at least 1 month in advance the external computing resources they want to use, for what purpose and how to reach the resources.
-	  E.g. specify the URL or IP-address. 
-	  This must be specified in the team description paper. 
+	  A team must announce to the TC at least 1 month in advance the external computing resources they want to use, for what purpose and how to reach the resources (e.g. specify the URL or IP address and port). Inspected software must meet the following \textbf{requirements:}
+	  \begin{itemize}
+	  	\item The software must be open source (BSD/GPL/etc), or
+        \item Detailed information about the propietary product must be provided (e.g. vendor, patent number, licencing, pricing, etc.), as well as publishing the interface for scientific use.
+	  \end{itemize}
+	All relevant information must be specified in the team description paper.
 	\item \textbf{Connection:} The robot may connect to \iterm{external computing resources} via a network connection, e.g. the Internet. 
 	  The competition organisation cannot make any guarantees concerning availability, connectivity and performance of the connection. 
 	  The robot should still be functional (albeit limited perhaps) if the \iterm{external computing resources} cannot be used for some reason.
@@ -21,6 +24,7 @@ Robots are allowed to use some form of external computing, for example in the fo
 	\item \textbf{Limit:} A robot is limited to use up to 5 \iterm{external computing resources}. 
 \end{enumerate}
 
+\textbf{Remark:} Teams are allowed to use their own software in the external computing devices (not only cloud services). This software must be publicly available to other teams for scientific purposes (evaluation, test, and benchmarking), as well as for TC for inspection. Although open-sourcing the software is not mandatory, this practice is advised and encouraged by the league.
 
 % Local Variables:
 % TeX-master: "../Rulebook"


### PR DESCRIPTION
- Addressed #278
- Cloud computing and other propietary solutions with closed code are allowed
  - Details on how to get the product must be provided.
- Open source software is allowed
  - The source must be specified.