### PR TITLE
GPSR with incremental scoring

### DIFF
--- a/tests/GPSR.tex
+++ b/tests/GPSR.tex
@@ -64,7 +64,8 @@ This test particularly focuses on the following aspects:
 	\end{itemize}
 
 	\item \textbf{Retrieving the command:} The robot must show it has understood the given command by repeating the command (i.e.~stating all the required information to accomplish the task.).
-	\item \textbf{Incremental scoring:} Scoring depends on the category chosen by the team leader and the previous successfully accomplished command. Thereby, scoring for a second and third command is possible only if the robot has already solved (not understood) a first and second command respectively. Referees determine when a command is considered accomplished or not.
+
+	\item \textbf{Incremental scoring:} Scoring depends on the category chosen by the team leader and the previous successfully accomplished command. Thereby, scoring for a second and third command depends on how well the robot solved (not understood) a first and second command respectively. Referees determine how well the command was accomplished and its impact on the incremental scoring of subsequent commands.
 \end{enumerate}
 
 \subsection{Referee and OC instructions}

--- a/tests/GPSR.tex
+++ b/tests/GPSR.tex
@@ -64,6 +64,7 @@ This test particularly focuses on the following aspects:
 	\end{itemize}
 
 	\item \textbf{Retrieving the command:} The robot must show it has understood the given command by repeating the command (i.e.~stating all the required information to accomplish the task.).
+	\item \textbf{Incremental scoring:} Scoring depends on the category chosen by the team leader and the previous successfully accomplished command. Thereby, scoring for a second and third command is possible only if the robot has already solved (not understood) a first and second command respectively. Referees determine when a command is considered accomplished or not.
 \end{enumerate}
 
 \subsection{Referee and OC instructions}


### PR DESCRIPTION
- Addressed #283
- Added additional rule explicitly explaining scoring is incremental.
- Is required to solve a first command to get points for the second
- Is required to solve a first and second command to get points for the third.
- The referee determines whether the command was successfully solved or not.