### PR TITLE
Corrected crossed references

### DIFF
--- a/introduction/Leagues.tex
+++ b/introduction/Leagues.tex
@@ -18,17 +18,17 @@
 	\vspace{-30pt}
 	\begin{center}
 		\includegraphics[width=0.25\textwidth]{images/toyota_hsr.png}
-		\label{fig:toyotaHSR}
 		\vspace{-10pt}
 		\caption{Toyota HSR}
+		\label{fig:toyotaHSR}
 	\end{center}
 
 	\vspace{-25pt}
 	\begin{center}
 		\includegraphics[width=0.20\textwidth]{images/softbank_pepper.png}
-		\label{fig:softbank-pepper}
 		\vspace{-10pt}
 		\caption{Softbank / Aldebaran Pepper}
+		\label{fig:softbank-pepper}
 	\end{center}
 \end{wrapfigure}
 Each league points out to a different aspect of service robotics, reason for which they target specific abilities.

--- a/tests/HelpMeCarry.tex
+++ b/tests/HelpMeCarry.tex
@@ -105,17 +105,17 @@ The possible obstacles are:
       \centering
       \includegraphics[width=2cm]{images/help_me_carry_bag.png}%
       \vspace{-10pt}
-      \label{fig:storing_groceries}
       %\caption{Example car with groceries.}
       \caption{Paper bag}
+      \label{fig:help_me_carry_paper_bag}
     \end{figure}
     \vspace{-10pt}
     \begin{figure}[H]
       \centering
       \includegraphics[width=\textwidth]{images/help_me_carry_car.png}%
       \vspace{-20pt}
-      \label{fig:storing_groceries}
       %\caption{Example car with groceries.}
+      \label{fig:help_me_carry_car}
       \caption{Car}
     \end{figure}
   \end{minipage}

--- a/tests/SetATableTidyUp.tex
+++ b/tests/SetATableTidyUp.tex
@@ -27,7 +27,7 @@ This test focuses on HRI, semantic mapping, object perception and manipulation.
 \begin{itemize}
 	\item[Part I:] Setting up the table
 	\begin{enumerate}
-		\item \textbf{Fetching command:} The operator requests the robot to set up the table. Optionally, the robot may ask the operator \textit{what has to be served}. The operator replies with the randomly selected (and undisclosed) option.
+		\item \textbf{Fetching command:} The operator requests the robot to set up the table. Optionally, the robot may ask the operator \textit{what has to be served}. The operator replies with the randomly selected (and undisclosed) option. \label{sattu:option}
 
 		\item \textbf{Setting the table:} The robot must safely and neatly place (i.e. without colliding with any existing object) all missing objects required for the meal. For example, carpet, fork, knife, spoon, and dish.
 
@@ -65,7 +65,7 @@ This test focuses on HRI, semantic mapping, object perception and manipulation.
 
 	\item \textbf{Spots and Spills:} The referees will mess up the table right after it has been set, by spreading breadcrumbs, spilling some liquid, adding spots of jam, etc. It must be clear the robot has detected them and is trying actively to clean them, even though the cleaning may be unsuccessful.
 
-	\item \textbf{Task variation:} The team may provide the referees a written set of at least 2 options for serving a meal (e.g. cereal and milk, sandwiches, toasts, Coffee and bread, etc.). These options must be written as possible answers to the robot question (step~\ref{sattu:s2} in section~\ref{sattu:task}). The correct execution of the specified variation should be clearly visible, e.g., choice of an object placed on the table.
+	\item \textbf{Task variation:} The team may provide the referees a written set of at least 2 options for serving a meal (e.g. cereal and milk, sandwiches, toasts, Coffee and bread, etc.). These options must be written as possible answers to the robot question (step~\ref{sattu:option} in section~\ref{sattu:task}). The correct execution of the specified variation should be clearly visible, e.g., choice of an object placed on the table.
 \end{enumerate}
 
 \subsection{Data recording}

--- a/tests/StoringGroceries.tex
+++ b/tests/StoringGroceries.tex
@@ -26,9 +26,9 @@ This test focuses on the detection and recognition of objects and their features
 		\centering
 		\includegraphics[width=\textwidth]{images/storing_groceries.png}%
 		\vspace{-10pt}
-		\label{fig:storing_groceries}
 		%\caption{Example shelf where objects will be placed.}
 		\caption{Shelf}
+		\label{fig:storing_groceries_shelf}
 	\end{figure}
 \end{minipage}
 


### PR DESCRIPTION
- Fixed cross reference in Set a Table and Clean Up test
- Verified all \label{} are placed after \caption{}