### PR TITLE
Removed bonus in Open Challenge for multi-league teams

### DIFF
--- a/tests/OpenChallenge.tex
+++ b/tests/OpenChallenge.tex
@@ -80,7 +80,7 @@ For sake of clarity, please consider the following example: Let be A, B two team
     \item Team B participates in both SSPL and OPL.
     \item Team A and B have qualified into Stage II.
 \end{itemize}
-Then, by aplying Rule \ref{rule:OC-inter-league-collaboration} the following statements can be concluded:
+Then, by aplying the \textit{Inter-league collaboration Rule} (See \refsec{rule:OC-inter-league-collaboration}) the following statements can be concluded:
 \begin{itemize}
   \item B OPL can not participate in A SSPL's open challenge.
   \item B OPL can not participate in B SSPL's open challenge.

--- a/tests/OpenChallenge.tex
+++ b/tests/OpenChallenge.tex
@@ -64,9 +64,11 @@ It is important to note that the jury may decide to end the demonstration if the
 		\item It must be made clear that the demonstrations from the two teams are not similar, otherwise the points cannot be awarded.
 		\item In case a team receives two (or more) bonuses, the maximum bonus will be taken.
 		\item The collaboration is possible even if one of the two teams has not reached Stage 2.
-		\item The team which does not participate in Stage 2 receives no points for this test.
+		\item A team not participating in Stage 2 receives no bonus points for this test.
 	\end{enumerate}
 \end{enumerate}
+
+\textbf{Inter-league collaboration}: Inter-league collaboration must be announced to the OC at least one day before the test. Teams participating in multiple @Home Leagues does receive no bonus for cooperation. Standard Platform robots are allowed to take part in the Open Challenge of the Open Platform League, but Open Platform robots can \emph{not} participate in any Standard Platform League's test. In the same sense, DSPL robots are not allowed in SSPL and vice versa.
 
 
 % Local Variables:

--- a/tests/OpenChallenge.tex
+++ b/tests/OpenChallenge.tex
@@ -55,20 +55,40 @@ It is important to note that the jury may decide to end the demonstration if the
 	\begin{enumerate}
 		\item if nothing is shown: in case of longer delays (more than one minute), e.g., when the robot does not start or when it got stuck;
 		\item if nothing new is shown: the demonstrated abilities were already shown in previous tests (to avoid dull demonstrations and push teams to present novel ideas).
-	\end{enumerate}
-
-	\item \textbf{Team-team-interaction:}  An extra bonus of up to \bonusRobotCoop points can be earned if robots from two teams (4 robots maximum, 2 from each team) successfully collaborate (robot-robot interaction).
-	\begin{enumerate}
-		\item This bonus is earned for both teams.
-		\item The robot(s) of the other team must only play a minor role in the total demonstration.
-		\item It must be made clear that the demonstrations from the two teams are not similar, otherwise the points cannot be awarded.
-		\item In case a team receives two (or more) bonuses, the maximum bonus will be taken.
-		\item The collaboration is possible even if one of the two teams has not reached Stage 2.
-		\item A team not participating in Stage 2 receives no bonus points for this test.
-	\end{enumerate}
+  \end{enumerate}
 \end{enumerate}
 
-\textbf{Inter-league collaboration}: Inter-league collaboration must be announced to the OC at least one day before the test. Teams participating in multiple @Home Leagues does receive no bonus for cooperation. Standard Platform robots are allowed to take part in the Open Challenge of the Open Platform League, but Open Platform robots can \emph{not} participate in any Standard Platform League's test. In the same sense, DSPL robots are not allowed in SSPL and vice versa.
+  \subsubsection{Team-team-interaction:} 
+  \label{rule:OC-team-team-interaction}
+  An extra bonus of up to \bonusRobotCoop points can be earned if robots from two teams (4 robots maximum, 2 from each team) successfully collaborate (robot-robot interaction).
+\begin{enumerate}
+  \item This bonus is earned for both teams.
+  \item The robot(s) of the other team must only play a minor role in the total demonstration.
+  \item It must be made clear that the demonstrations from the two teams are not similar, otherwise the points cannot be awarded.
+  \item In case a team receives two (or more) bonuses, the maximum bonus will be taken.
+  \item The collaboration is possible even if one of the two teams has not reached Stage 2.
+  \item A team not participating in Stage 2 receives no bonus points for this test.
+\end{enumerate}
+
+\paragraph*{Inter-league collaboration}:
+\label{rule:OC-inter-league-collaboration}
+Inter-league collaboration must be announced to the OC at least one day before the test. Teams participating in multiple @Home Leagues does receive no bonus for cooperation. Standard Platform robots are allowed to take part in the Open Challenge of the Open Platform League, but Open Platform robots can \emph{not} participate in any Standard Platform League's test. In the same sense, DSPL robots are not allowed in SSPL and vice versa.
+
+For sake of clarity, please consider the following example: Let be A, B two teams participating in RoboCup @Home where
+\begin{itemize}
+    \item Team A participates in SSPL.
+    \item Team B participates in both SSPL and OPL.
+    \item Team A and B have qualified into Stage II.
+\end{itemize}
+Then, by aplying Rule \ref{rule:OC-inter-league-collaboration} the following statements can be concluded:
+\begin{itemize}
+  \item B OPL can not participate in A SSPL's open challenge.
+  \item B OPL can not participate in B SSPL's open challenge.
+  \item A SSPL can participate in B OPL's open challenge. Team A and B get a bonus because A <> B.
+  \item B SSPL can participate in B OPL's open challenge. There is no bonus because B = B.
+\end{itemize}
+
+
 
 
 % Local Variables:


### PR DESCRIPTION
The rule Team-team-interaction would grant a bonus to one single team participating in two leagues as they are registered as two different teams.

A remark has been added specifying that interleague collaboration is possible (SPL->OPL only), but teams competing in several leagues can't benefit from the bonus.