### PR TITLE
Remove leaving the arena after SPR.

### DIFF
--- a/tests/SPR.tex
+++ b/tests/SPR.tex
@@ -32,7 +32,7 @@ This test focuses on human detection, sound localization, speech recognition, an
     This process is repeated with 5 (possibly) different people. 
     The game will end when the 5th question has been made, following the same distribution of questions as in the riddle game. The robot must answer the question without asking confirmation. Questions may be repeated once.
     
-    \item \textbf{Leave} Th robot must leave the arena/test area to make place for the next robot to be tested. 
+    \item \textbf{Leave} The robot must leave the arena/test area after all questions have been asked or when instructed to do so.
 \end{itemize}
 
 \subsection{Additional rules and remarks}
@@ -92,7 +92,7 @@ The referee needs to
 \begin{itemize}
     \item Announce the placement of the robots
     \item choose the volunteers for the second part of the test, and clearly explain the procedure to them.
-    \item Announce where the robot should leave to after the test. 
+    \item When the test is held outside the arena, announce (way)point the robot to leave to
 \end{itemize}
 
 \newpage

--- a/tests/SPR.tex
+++ b/tests/SPR.tex
@@ -92,7 +92,7 @@ The referee needs to
 \begin{itemize}
     \item Announce the placement of the robots
     \item choose the volunteers for the second part of the test, and clearly explain the procedure to them.
-    \item When the test is held outside the arena, announce (way)point the robot to leave to
+    \item When the test is held outside the arena, announce the (way)point through which the robot shall leave
 \end{itemize}
 
 \newpage

--- a/tests/SPR.tex
+++ b/tests/SPR.tex
@@ -31,6 +31,8 @@ This test focuses on human detection, sound localization, speech recognition, an
     \end{itemize}
     This process is repeated with 5 (possibly) different people. 
     The game will end when the 5th question has been made, following the same distribution of questions as in the riddle game. The robot must answer the question without asking confirmation. Questions may be repeated once.
+    
+    \item \textbf{Leave} Th robot must leave the arena/test area to make place for the next robot to be tested. 
 \end{itemize}
 
 \subsection{Additional rules and remarks}
@@ -90,6 +92,7 @@ The referee needs to
 \begin{itemize}
     \item Announce the placement of the robots
     \item choose the volunteers for the second part of the test, and clearly explain the procedure to them.
+    \item Announce where the robot should leave to after the test. 
 \end{itemize}
 
 \newpage

--- a/tests/SPR.tex
+++ b/tests/SPR.tex
@@ -31,8 +31,6 @@ This test focuses on human detection, sound localization, speech recognition, an
     \end{itemize}
     This process is repeated with 5 (possibly) different people. 
     The game will end when the 5th question has been made, following the same distribution of questions as in the riddle game. The robot must answer the question without asking confirmation. Questions may be repeated once.
-
-    \item \textit{Leave:} The robot leaves the room through the designated door.
 \end{itemize}
 
 \subsection{Additional rules and remarks}


### PR DESCRIPTION
It's fine if the operators move the robot away.

Addresses https://github.com/RoboCupAtHome/RuleBook/issues/310 