### PR TITLE
Several aesthetic changes

### DIFF
--- a/score_sheets.tex
+++ b/score_sheets.tex
@@ -43,39 +43,7 @@
 %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% %%
 %%  L E A G U E S                       %%
 %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% %%
-\ifdefined\league
-\else%
-  % Provided for compatibility with older versions
-  \input{teams/teams.tex}
-  \newcommand{\league}{}
-  \newcommand{\leagueFullName}{}
-\fi
-
-\ifthenelse{\equal{\league}{OPL}}{
-  \input{teams/OPL.tex}
-  \newcommand{\leagueFullName}{Open Platform League}
-}{}
-\ifthenelse{\equal{\league}{DSPL}}{
-  \input{teams/DSPL.tex}
-  \newcommand{\leagueFullName}{Domestic Standard Platform League}
-  }{}
-\ifthenelse{\equal{\league}{SSPL}}{
-  \input{teams/SSPL.tex}
-  \newcommand{\leagueFullName}{Social Standard Platform League}}{}
-
-\newcommand{\ifNotSSPL}[1]{
-  \ifthenelse{\equal{\league}{} \OR \equal{\league}{OPL} \OR \equal{\league}{DSPL}}{#1}{}
-}
-
-\newcommand{\ifSSPL}[1]{
-  \ifthenelse{\equal{\league}{} \OR \equal{\league}{SSPL}}{#1}{}
-}
-
-\newcommand{\ifLeague}[2]{
-  \ifNotSSPL{#1}
-  \ifSSPL{#2}
-}
-% \expandafter\expandafter\newcommand\TEAMSSTAGEONE{\csname TEAMS\league \endcsname}
+\loadTeamsListFile
 
 %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% %%
 %%  H E A D I N G S                     %%
@@ -238,3 +206,4 @@
 
 \end{document}
 
+\grid

--- a/scoresheets/EEGPSR.tex
+++ b/scoresheets/EEGPSR.tex
@@ -16,7 +16,7 @@ The maximum time for this test is 40 minutes.\\
 
 	\scoreheading{Manipulation}
 	\scoreitem{ 5}{Grab/place an object}
-	\scoreitem{30}{Manipulation: two-handed, in narrow spaces*, tiny/heavy/slippery* objects}
+	\scoreitem{30}{ Manipulation: {\scriptsize two-handed, in narrow spaces*, tiny/heavy/slippery* objects}}
 	\scoreitem{20}{Open/close a door/drawer*}
 	\scoreitem{50}{Pouring, pressing, uncapping, turning on/off, twisting}
 	

--- a/scoresheets/GPSR.tex
+++ b/scoresheets/GPSR.tex
@@ -6,7 +6,7 @@ The maximum time for this test is 10 minutes.
 \begin{scorelist}
 	\scoreheading{Getting instructions}
 	\scoreitem[3]{10}{Understanding the command on the $1^{st}$ attempt}
-	\scoreitem[3]{ 5}{Understanding the command on the $1^{st}$ attempt (Custom Operator)}
+	\scoreitem[3]{ 5}{\small Understanding the command on the $1^{st}$ attempt (Custom Operator)}
 	\scoreitem[3]{ 1}{Understanding the command at a later attempt}
 
 	\scoreheading{First Command Successfully Solved}

--- a/scoresheets/HelpMeCarry.tex
+++ b/scoresheets/HelpMeCarry.tex
@@ -7,6 +7,7 @@ The maximum time for this test is 5 minutes.
 	\scoreitem{15}{Follow operator to the car}
 	\scoreitem{ 5}{Understand the destination}
 	
+\ifNotSSPL{
 	% These are mutually exclusive, max score is thus 20
 	\scoreheading{Bag pick-up (OPL \& DSPL only)}
 	\scoreitem{0}{Put up hand, closing it after waiting time elapses}
@@ -21,19 +22,26 @@ The maximum time for this test is 5 minutes.
 	\scoreitem{30}{Open door without help}
 	\scoreitem{10}{Guide operator outside the arena}
 	\scoreitem{15}{Guide operator to the car}
+}
 
+\ifSSPL{
 	\scoreheading{SSPL only Tasks} % 100 pts
 	\scoreitem{10}{Tell the time to the stranger}
 	\scoreitem{30}{Re-enter the arena}
 	\scoreitem{20}{Find the person at the specified room}
 	\scoreitem{10}{Guide operator outside the arena}
 	\scoreitem{30}{Guide operator to the car}
+}
 	
 	\scoreheading{Obstacle avoidance} % 70 pts
 	\scoreitem{20}{Avoiding small (box-sized) object}
 	\scoreitem{20}{Avoiding 3D (hard-to-see) object}
+\ifSSPL{%
 	\scoreitem{30}{[SSPL] Asking a person to step aside (\textit{smart} obstacle)}
+}%
+\ifNotSSPL{%
 	\scoreitem{30}{[DSPL \& OPL] Moving away movable object}
+}%
 	
 	\setTotalScore{200}
 \end{scorelist}

--- a/scoresheets/SPR.tex
+++ b/scoresheets/SPR.tex
@@ -11,19 +11,23 @@ The maximum time for this test is 5 minutes.
 	\scoreitem[ 5]{5}{Correctly answered a question}
 	\scoreitem{ 5}{Answering all 5 riddle game question}
 
+\ifDSPL{
 	\scoreheading{[DSPL only] Blind man's bluff game} % Max 130
 	\scoreitem[10]{ 5}{Understanding question on the first attempt}   % 50
 	\scoreitem[10]{ 2}{Understanding question on the second attempt}  % -- (20)
 	\scoreitem[10]{ 2}{Correctly answered a question}                 % 20
 	\scoreitem[10]{ 5}{Turned towards person asking the question}     % 50
 	\scoreitem{10}{Answering all 10 blind man's bluff questions}      % 10
+}
 
+\ifNotDSPL{
 	\scoreheading{[OPL \& SSPL] Blind man's bluff game} % Max 130
 	\scoreitem[ 5]{10}{Understanding question on the first attempt}   % 50
 	\scoreitem[ 5]{ 5}{Understanding question on the second attempt}  % -- (25)
 	\scoreitem[ 5]{ 5}{Correctly answered a question}                 % 25
 	\scoreitem[ 5]{10}{Turned towards person asking the question}     % 50
 	\scoreitem{ 5}{Answering all 5 blind man's bluff questions}       %  5	
+}
 
 	\setTotalScore{200}	
 \end{scorelist}

--- a/scoresheets/StoringGroceries.tex
+++ b/scoresheets/StoringGroceries.tex
@@ -11,7 +11,6 @@ If not, the test ends.
 	\scoreheading{Opening the door}
 	\scoreitem[1]{20}{Opening the door without human help}
 	% Total: 20
-
 	\scoreheading{Moving objects}
 	\scoreitem[5]{10}{Successfully grasping an object (5 cm for more than 10 seconds)}
 	% Total: 50
@@ -21,14 +20,14 @@ If not, the test ends.
 	% Total: 50
 
 	\scoreheading{Recognizing known or alike objects}
-	\scoreitem[10]{5}{Every correctly recognized known or alike object in the report file} 
+	\scoreitem[10]{5}{\small Every correctly recognized known or alike object in the report file} 
 	% Total: 50
 	
 	\scoreheading{Recognizing unknown objects}
 	\scoreitem[10]{5}{Correctly label unknown object as \quotes{Unknown}}
-	\scoreitem[5]{20}{Label a \textit{pair} of unknown objects with the same label (e.g label each of the 2 papayas both as e.g \quotes{class A})}
-	\scoreitem[10]{15}{Label unknown object as correct category (e.g. label a papaya as fruit)}
-	\scoreitem[10]{15}{Label unknown object as correct class (e.g. label a papaya as papaya)}
+	\scoreitem[5]{20}{Label a \textit{pair} of unknown objects with the same label (e.g label both papayas both as \quotes{class A})}
+	\scoreitem[10]{15}{\footnotesize Label unknown object as correct category (e.g. label a papaya as fruit)}%
+	\scoreitem[10]{15}{\footnotesize Label unknown object as correct class (e.g. label a papaya as papaya)}%
 	% Total: 150
 	
 	\scoreheading{Incorrect recognitions}

--- a/setup/macros.tex
+++ b/setup/macros.tex
@@ -8,6 +8,7 @@
 
 \input{./setup/macros_score_sheets.tex}
 \input{./setup/macros_open_demonstrations.tex}
+\input{./setup/macros_leagues.tex}
 
 \newcommand{\rulebookVersion}{\STATE\ version for RoboCup \YEAR\xspace(\VERSION)}
 

--- a/setup/macros_leagues.tex
+++ b/setup/macros_leagues.tex
@@ -1,0 +1,88 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%
+%%          $Id: macros_leagues.tex 399 2017-06-04 13:36:00Z matamoros $
+%%    author(s): RoboCupAtHome Technical Committee(s)
+%%  description: Macros for the RoboCupAtHome rulebook
+%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\ifdefined\league
+\else%
+    % Provided for compatibility with older versions
+    \newcommand\teamsListFile{teams/teams.tex}
+    \newcommand{\league}{}
+    \newcommand{\leagueFullName}{}
+\fi
+
+%% Import team from the Open Standard Platform League %%%%%%%%%%% %%
+\ifthenelse{\equal{\league}{OPL}}{
+    \newcommand\teamsListFile{teams/OPL.tex}
+    \newcommand{\leagueFullName}{Open Platform League}
+}{}
+
+%% Import team from the Domestic Standard Platform League %%%%%%% %%
+\ifthenelse{\equal{\league}{DSPL}}{
+    \newcommand\teamsListFile{teams/DSPL.tex}
+    \newcommand{\leagueFullName}{Domestic Standard Platform League}
+}{}
+
+%% Import team from the Social Standard Platform League %%%%%%%%% %%
+\ifthenelse{\equal{\league}{SSPL}}{
+    \newcommand\teamsListFile{teams/SSPL.tex}
+    \newcommand{\leagueFullName}{Social Standard Platform League}
+}{}
+
+
+%% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% %%
+%%  Per league macros                                             %%
+%% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% %%
+
+%% Domestic Standard Platform League %%%%%%%%%%%%%%%%%%%%%%%%%%%% %%
+\newcommand{\ifDSPL}[1]{
+    \ifthenelse{\equal{\league}{} \OR \equal{\league}{DSPL}}{#1}{}
+}
+
+\newcommand{\ifNotDSPL}[1]{
+    \ifthenelse{\equal{\league}{} \OR \equal{\league}{OPL} \OR \equal{\league}{SSPL}}{#1}{}
+}
+
+
+%% Open Platform League %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% %%
+\newcommand{\ifOPL}[1]{
+    \ifthenelse{\equal{\league}{} \OR \equal{\league}{OPL}}{#1}{}
+}
+
+\newcommand{\ifNotOPL}[1]{
+    \ifthenelse{\equal{\league}{} \OR \equal{\league}{DSPL} \OR \equal{\league}{SSPL}}{#1}{}
+}
+
+
+%% Open Standard Platform League %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% %%
+\newcommand{\ifSSPL}[1]{
+    \ifthenelse{\equal{\league}{} \OR \equal{\league}{SSPL}}{#1}{}
+}
+
+\newcommand{\ifNotSSPL}[1]{
+    \ifthenelse{\equal{\league}{} \OR \equal{\league}{OPL} \OR \equal{\league}{DSPL}}{#1}{}
+}
+
+% \newcommand{\ifLeague}[2]{
+%     \ifNotSSPL{#1}
+%     \ifSSPL{#2}
+% }
+
+
+
+
+%% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% %%
+%%  List of teams import macro                                    %%
+%% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% %%
+
+\newcommand{\loadTeamsListFile}{%
+    \input{\teamsListFile}
+}
+
+% \expandafter\expandafter\newcommand\TEAMSSTAGEONE{\csname TEAMS\league \endcsname}
+
+% Local Variables:
+% TeX-master: "../Rulebook"
+% End:


### PR DESCRIPTION
Several aesthetic changes
Scoresheet shrink and buffs
- Added rulebook-wide macros for defining per-league entries
	- Entries are always printed in the rulebook
	- Entries are always printed in rulebooks scoresheet
	- Entries are only printed in the scoresheet booklet of the pertinent league
- Score sheet length shortened in league sensitive tests
	- All content for other leagues has been removed
- Size fixings
	- GPSR scoresheet: ```Manipulation: two-handed, in narrow spaces*, tiny/heavy/slippery* objects``` reduced from two lines to one.
	- GPSR scoresheet: ```Understanding the command on the $1^{st}$ attempt (Custom Operator)``` reduced from two lines to one.
	- Storing Groceries scoresheet: ```Label unknown object as correct category (e.g. label a papaya as fruit)``` reduced from two lines to one.
	- Storing Groceries scoresheet: ```Label unknown object as correct class (e.g. label a papaya as papaya)``` reduced from two lines to one.