### PR TITLE
Add Official Standard Laptop specs and rules (compulsory for DSPL)

### DIFF
--- a/Setup.tex
+++ b/Setup.tex
@@ -119,6 +119,7 @@ Safety is the most important issue when interacting with humans and operating in
 		\begin{itemize}
 			\item Neat appearance
 			\item No modifications have been made
+			\item Specifications of the \iaterm{Official Standard Laptop}{OSL} (if required)
 		\end{itemize}
 		\item \textbi{Open Platform robots}
 		\begin{itemize}

--- a/general_rules/ExternalComputing.tex
+++ b/general_rules/ExternalComputing.tex
@@ -29,9 +29,17 @@ Robots are allowed to use some form of external computing, for example in the fo
 
 \subsection{Official Standard Laptop for DSPL}
 \label{rule:osl_dspl}
-In the Domestic Standard Platform League, teams are required to have the \iaterm{Official Standard Laptop}{OSL} connected to the Toyota HSR via Ethernet cable, safely located in the TOYOTA HSR \iterm{Mounting Bracket} provided by TOYOTA for this purpose.
+% 
+% Mandatory mounting bracket
+% 
+% In the Domestic Standard Platform League, teams are required to have the \iaterm{Official Standard Laptop}{OSL} connected to the Toyota HSR via Ethernet cable, safely located in the TOYOTA HSR \iterm{Mounting Bracket} provided by TOYOTA for this purpose.
 
-The robot must wear the \iterm{Mounting Bracket} with the OSL in all the tests during the competition and the OSL must be connected to the robot whether it's used or not. Since the use of the \iterm{Mounting Bracket} and the presence of the OSL is compulsory, teams missing this requirement will not be allowed to compete.
+% The robot must wear the \iterm{Mounting Bracket} with the OSL in all the tests during the competition and the OSL must be connected to the robot whether it's used or not. Since the use of the \iterm{Mounting Bracket} and the presence of the OSL is compulsory, teams missing this requirement will not be allowed to compete.
+
+% 
+% Optional mounting bracket
+% 
+In the Domestic Standard Platform League, teams may use the \iaterm{Official Standard Laptop}{OSL} connected to the Toyota HSR via Ethernet cable, safely located in the TOYOTA HSR \iterm{Mounting Bracket} provided by TOYOTA for this purpose.
 
 \subsubsection{Technical Specifications}
 The technical specifications for the Official Standard Laptop in the Domestic Standard Platform League are the following:

--- a/general_rules/ExternalComputing.tex
+++ b/general_rules/ExternalComputing.tex
@@ -26,7 +26,29 @@ Robots are allowed to use some form of external computing, for example in the fo
 
 \textbf{Remark:} Teams are allowed to use their own software in the external computing devices (not only cloud services). This software must be publicly available to other teams for scientific purposes (evaluation, test, and benchmarking), as well as for TC for inspection. Although open-sourcing the software is not mandatory, this practice is advised and encouraged by the league.
 
+
+\subsection{Official Standard Laptop for DSPL}
+\label{rule:osl_dspl}
+In the Domestic Standard Platform League, teams are required to have the \iaterm{Official Standard Laptop}{OSL} connected to the Toyota HSR via Ethernet cable, safely located in the TOYOTA HSR Backpack provided by TOYOTA for this purpose.
+
+The robot must wear the backpack with the OSL in all the tests during the competition and the OSL must be connected to the robot whether it's used or not. Since the use of the backpack and the presence of the OSL is compulsory, teams missing this requirement will not be allowed to compete.
+
+\subsubsection{Technical Specifications}
+The technical specifications for the Official Standard Laptop in the Domestic Standard Platform League are the following:
+
+
+ \begin{itemize}
+  \item \textbf{Brand and model:} DELL Alienware 15 or 17
+  \item \textbf{CPU:} Core-i7 series
+  \item \textbf{RAM:} 16GB or 32GB
+  \item \textbf{GPU:} NVIDIA GeForce GTX 1070 or 1080
+  \item \textbf{Storage:} Unrestricted.
+\end{itemize}
+
+No other brands or models will be accepted. There are no constrains regarding the software installed in the OSL but no additional hardware is allowed.
+
+The referees, Technical Committee, and Organizing Committee members may run random checks anytime during the competition prior to the test to verify that the laptop in the TOYOTA HSR Backpack has no additional hardware plugged in, and matches the authorized specifications.
+
 % Local Variables:
 % TeX-master: "../Rulebook"
 % End:
- 

--- a/general_rules/ExternalComputing.tex
+++ b/general_rules/ExternalComputing.tex
@@ -29,9 +29,9 @@ Robots are allowed to use some form of external computing, for example in the fo
 
 \subsection{Official Standard Laptop for DSPL}
 \label{rule:osl_dspl}
-In the Domestic Standard Platform League, teams are required to have the \iaterm{Official Standard Laptop}{OSL} connected to the Toyota HSR via Ethernet cable, safely located in the TOYOTA HSR Backpack provided by TOYOTA for this purpose.
+In the Domestic Standard Platform League, teams are required to have the \iaterm{Official Standard Laptop}{OSL} connected to the Toyota HSR via Ethernet cable, safely located in the TOYOTA HSR \iterm{Mounting Bracket} provided by TOYOTA for this purpose.
 
-The robot must wear the backpack with the OSL in all the tests during the competition and the OSL must be connected to the robot whether it's used or not. Since the use of the backpack and the presence of the OSL is compulsory, teams missing this requirement will not be allowed to compete.
+The robot must wear the \iterm{Mounting Bracket} with the OSL in all the tests during the competition and the OSL must be connected to the robot whether it's used or not. Since the use of the \iterm{Mounting Bracket} and the presence of the OSL is compulsory, teams missing this requirement will not be allowed to compete.
 
 \subsubsection{Technical Specifications}
 The technical specifications for the Official Standard Laptop in the Domestic Standard Platform League are the following:
@@ -47,7 +47,7 @@ The technical specifications for the Official Standard Laptop in the Domestic St
 
 No other brands or models will be accepted. There are no constrains regarding the software installed in the OSL but no additional hardware is allowed.
 
-The referees, Technical Committee, and Organizing Committee members may run random checks anytime during the competition prior to the test to verify that the laptop in the TOYOTA HSR Backpack has no additional hardware plugged in, and matches the authorized specifications.
+The referees, Technical Committee, and Organizing Committee members may run random checks anytime during the competition prior to the test to verify that the laptop in the TOYOTA HSR \iterm{Mounting Bracket} has no additional hardware plugged in, and matches the authorized specifications.
 
 % Local Variables:
 % TeX-master: "../Rulebook"


### PR DESCRIPTION
This patch adds to the rulebook the "Official Standard Laptop for DSPL" section. This section makes mandatory the use of the OSL in DSPL, as well as restricting the use of any hardware attached to the OSL and allowing Referees/TC/OC to run random checks.

Robot Inspection is modified to include the inspection of the OSL. Changes are compliant with what was discussed and decided in #366 and #368