### PR TITLE
Comment out all mentions to data recording bonus

### DIFF
--- a/GeneralRules.tex
+++ b/GeneralRules.tex
@@ -9,23 +9,23 @@
 \label{chap:rules}
 
 These are the general rules and regulations for the competition in the RoboCup@Home league.
-Every rule in this section can be considered to implicitly include the 
+Every rule in this section can be considered to implicitly include the
 term \emph{\quotes{unless stated otherwise}}, meaning that additional or contrary rules in particular
-test specifications have a higher priority than those mentioned herein in the general rules and regulations.  
+test specifications have a higher priority than those mentioned herein in the general rules and regulations.
 
 \input{general_rules/TeamRegistration}
 
 \section{Audience interaction}
-Direct interaction with the audience is not a part of most challenges, though some explicitly require it in an effort to make robots step out of the laboratory. 
+Direct interaction with the audience is not a part of most challenges, though some explicitly require it in an effort to make robots step out of the laboratory.
 
-Informing the audience however is important for the league. 
+Informing the audience however is important for the league.
 \input{general_rules/vizbox}
 
 \input{general_rules/Scenario}
 
 \input{general_rules/Robots}
 
-\input{general_rules/DataRecording}
+% \input{general_rules/DataRecording}
 
 \input{general_rules/ExternalDevices}
 

--- a/Rulebook.tex
+++ b/Rulebook.tex
@@ -66,7 +66,7 @@
   colorlinks   = true,
   anchorcolor  = blue,
   linkcolor    = blue,
-  urlcolor     = blue, 
+  urlcolor     = blue,
 }
 
 %%% HEADINGS & PAGE STYLE %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -128,27 +128,28 @@
 \label{chap:stage_I}
 
 \begin{itshape}
-\iterm{Stage~I} comprehends five \textbf{ability tests} and an \textbf{integration test} along with an open demonstration for the audience. 
-Each ability test is designed to evaluate the average performance of the robot in one particular skill, providing data for benchmarking. 
+\iterm{Stage~I} comprehends five \textbf{ability tests} and an \textbf{integration test} along with an open demonstration for the audience.
+Each ability test is designed to evaluate the average performance of the robot in one particular skill
+% , providing data for benchmarking.
 Meanwhile, the integration test has been designed to evaluate how this abilities work together while solving a common task.
 
 The total score for ability and integration tests is the average of the best two performances out of preferably three performances (given the time constraints of a competition).
 The point of this is to both eliminate good and bad luck for the robots/teams and to get a more objective view of the performance,
-  not to give teams time to tweak the robot between test performances. 
+  not to give teams time to tweak the robot between test performances.
 
-\iterm{Following and Guiding} (demonstration for the audience) goes out of the arena and into the venue between the audience. 
+\iterm{Following and Guiding} (demonstration for the audience) goes out of the arena and into the venue between the audience.
 
 \end{itshape}
 
 \subsection*{Scheduling}
-For maximal efficiency, teams will be scheduled interleaved: 
+For maximal efficiency, teams will be scheduled interleaved:
   Team A does an attempt while team B sets up their robot. When A is done, it moves out the way for team B, then B attempts while A sets up the robot again etc.
 
 The preparing team should prepare their robot close to the place of the test, but not interfere with the performing robot.
 Prepared robots must wait at this preparation location until commanded to start the test.
-When commanded to start, the robot must move automatically beyond this point. 
+When commanded to start, the robot must move automatically beyond this point.
 
-Robot should be ready to start the next attempt to the same test as fast as possible: 
+Robot should be ready to start the next attempt to the same test as fast as possible:
   when the performing robot is done with a attempt, the next robot must be ready to go with the start of a button or a voice command.
 
 \newpage
@@ -177,7 +178,7 @@ In the \iterm{Open Challenge} the robot must be able to show to the \iaterm{Tech
 \section*{Robot \& team cooperation}
 We encourage robots and teams to work together when performing tests.
 For scoring, points are awarded per subtask. The robot (and thus team) performing the subtask gets the points.
-For example, in the Restaurant test, if one robot of team A can take the order and another robot of team B delivers the order, then the points for taking the order go to team A, while the points for delivering go to team B. 
+For example, in the Restaurant test, if one robot of team A can take the order and another robot of team B delivers the order, then the points for taking the order go to team A, while the points for delivering go to team B.
 Of course, team A \& B can both perform the test in their own turn.
 
 \end{itshape}

--- a/setup/macros_score_sheets.tex
+++ b/setup/macros_score_sheets.tex
@@ -1,11 +1,11 @@
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Macros for generating score sheets for RoboCup@Home              %
 % to be used in the rulebook or during the competition             %
-%                                                                  % 
+%                                                                  %
 % Author: Dirk Holz & David Gossow                                 %
 % Modif : Mauricio Matamoros                                       %
 % $Id: macros_score_sheets.tex 429 2013-04-30 10:09:55Z holz $     %
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
 \usepackage{calc}
@@ -36,7 +36,7 @@
 \newcommand{\continueAvailable}{true}
 
 % set \dataRecordingBonus to true for data recording bonus
-\newcommand{\dataRecordingBonus}{true}
+\newcommand{\dataRecordingBonus}{false}
 
 % name of the current test, is set automatically in the rulebook
 \newcommand{\currentTest}{}
@@ -110,26 +110,26 @@
   \newpage
 
   \renewcommand{\scoresheetOptions}{#1}
-  
+
   \begin{minipage}[t]{0.8\textwidth}%
     \vspace{0pt}
     {\huge \textbf{Score Sheet} }
-    
+
     \vspace{2 em}
-    
+
     \begin{tabular}{ @{} l l l}
       \textbf{Test:} & \currentTest \\[.9 em]
-      
+
       \ifEvaluationSheet{}{%
         \textbf{Team name:} & \scoreline[0.6]\\[.9 em]%
       }%
-      % 
+      %
       \textbf{Referee name:} & \scoreline[0.6]\\[.9 em]%
-      %	
+      %
       %	\ifEvaluationSheet{}{%
       %   \textbf{Restart:} & \Square ~1st try \hspace{1 em} \Square ~2nd try
       %	}
-      %	
+      %
       % test repetition checkboxes (for stage 2 tests)
       \ifthenelse{ \equal{#1}{repeatable} }{%
 	\textbf{Test repetition:} & \Square ~1st \hspace{1 em} \Square ~2nd\\[.9em]%
@@ -192,26 +192,26 @@
   \ifShortScoresheet {
     \begin{tabular*}{\textwidth}{@{} @{\extracolsep{\fill}} p{0.8\linewidth} r @{}}
       \ifEvaluationSheet{
-        \textbf{Team} & \textbf{Score} \\ \hline 
+        \textbf{Team} & \textbf{Score} \\ \hline
       }{%
-        \textbf{Action} & \textbf{Score} \\ \hline 
+        \textbf{Action} & \textbf{Score} \\ \hline
       }
-    }{  
+    }{
       % else:
       % \begin{tabular*}{\textwidth}{@{}p{0.65\linewidth}lp{0.15\linewidth}@{}}
-      %   \textbf{Action} & \textbf{Score} & \multicolumn{1}{l}{\textbf{Success}}\\ \hline 
+      %   \textbf{Action} & \textbf{Score} & \multicolumn{1}{l}{\textbf{Success}}\\ \hline
       \ifEvaluationSheet{
         \begin{tabular*}{\textwidth}{@{} @{\extracolsep{\fill}} p{0.7\linewidth} r r @{}}
-          \textbf{Team} & \textbf{Score} & \textbf{Result}\\ \hline 
+          \textbf{Team} & \textbf{Score} & \textbf{Result}\\ \hline
         }{
           \ifthenelse{\equal{\threeAttempts}{true}}{
             \begin{tabular*}{\textwidth}{@{} @{\extracolsep{\fill}} p{0.6\linewidth} r r r r @{}}
-            \textbf{Action} & \textbf{Score} & \textbf{\small $1^{st}$ try} & \textbf{\small $2^{nd}$ try} & \textbf{\small$3^{rd}$ try} \\ \hline 
+            \textbf{Action} & \textbf{Score} & \textbf{\small $1^{st}$ try} & \textbf{\small $2^{nd}$ try} & \textbf{\small$3^{rd}$ try} \\ \hline
           }
           %else
           {
             \begin{tabular*}{\textwidth}{@{} @{\extracolsep{\fill}} p{0.6\linewidth} r r r @{}}
-            \textbf{Action} & \textbf{Score} \ifthenelse{\equal{\retryAvailable}{true}}{& \textbf{1st try} & \textbf{2nd try}}{ & \textbf{Only try}} \\ \hline 
+            \textbf{Action} & \textbf{Score} \ifthenelse{\equal{\retryAvailable}{true}}{& \textbf{1st try} & \textbf{2nd try}}{ & \textbf{Only try}} \\ \hline
           }
         }
       }
@@ -220,22 +220,22 @@
         % end
 
 	\ifEvaluationSheet{}{%
-          
+
           % calculate max. score, outstanding bonus %%%%%%%
           \ifthenelse{\value{currOutstandingBonus} = 0}{%
             \setcounter{currOutstandingBonus}{ \value{currTestScore} / 10 }
           }{}
           \setcounter{currTestScoreTotal}{ \value{currTestScore} + \value{currOutstandingBonus} }
           \setcounter{currTestScoreTotalWithoutBonus}{ \value{currTestScore} }
-          
+
 
           % Special penalties & bonuses %%%%%%%%%%%%%%%%
           \scoreheading{Special penalties \& standard bonuses}
 
           \ifthenelse {\equal{\dataRecordingBonus}{true}}{\scoreitem{10}{Contributing with recorded data ($\frac{\sum gathered\ points}{max\ points} \times$) \ifShortScoresheet{(see sec.~\ref{rule:datarecording})}{}}}{}
-          
+
           \scoreitem{-50}{Not attending \ifShortScoresheet{(see sec.~\ref{rule:not_attending})}{}}
-          
+
           \ifthenelse{\equal{\scorelistOptions}{openDoorSignal}}{
             \scoreitem{-10}{Using start button \ifShortScoresheet{(see sec.~\ref{rule:start_button})}{}}
           }{}
@@ -243,7 +243,7 @@
           % \ifthenelse{\value{currOutstandingBonus} = 0}{
           \scoreitem{\thecurrOutstandingBonus}{Outstanding performance \ifShortScoresheet{(see sec.~\ref{rule:outstanding_performance})}{}}
           % }{}
-          
+
           % Total score %%%%%%%%%%%%%%%%
           \hline\\
           % \textbf{Total score} & \scoring{ \thecurrTestScoreTotal } %
@@ -253,7 +253,7 @@
             \textbf{\textit{Score per try}} & \scoring{ \thecurrTestScoreTotalWithoutBonus } %
           }
           % add line to put in total:
-          \ifShortScoresheet{}{& \attemptScoreLines} \\   
+          \ifShortScoresheet{}{& \attemptScoreLines} \\
           \ifShortScoresheet{
             \textbf{Total score} (excluding penalties and bonuses) & \scoring{ \thecurrTestScoreTotalWithoutBonus } %
           }{
@@ -264,14 +264,14 @@
 	}
 
       \end{tabular*}
-      
+
     }
 
 
     %% Score sheet table entries %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
     % for loop helper
-    % usage: \forloop[step]{counter}{initial_value}{conditional}{code_block} 
+    % usage: \forloop[step]{counter}{initial_value}{conditional}{code_block}
     \newcommand{\forloop}[5][1]%
     {%
       \setcounter{#2}{#3}%
@@ -306,14 +306,14 @@
       \ifthenelse{ #2 > 0 }{
         \addtocounter{currTestScore}{ #2 * #1 }
       }{}%
-      % 
+      %
       \begin{minipage}[t]{\linewidth} {#3} \vspace{0.1 em} \end{minipage} & %
       \scoring{ \ifthenelse{ \equal{#1}{1} }{}{ #1 $\times$} \ifthenelse{ \equal{#2}{0} }{}{ #2}}%
-      % insert check marks:	
+      % insert check marks:
       %	\ifShortScoresheet{}{ & \forloop{ct}{0}{\value{ct} < #1}{ \Square}} \\[3pt]
       % insert line
       \ifShortScoresheet{ %
-        \\ 
+        \\
       }{ % else
         \ifEvaluationSheet{}{& \attemptScoreLines} \\[0pt]
       }

--- a/tests/HelpMeCarry.tex
+++ b/tests/HelpMeCarry.tex
@@ -18,10 +18,10 @@ The operator (the robot's owner) has a set of bags (and possibly other objects) 
 \begin{enumerate}
   \item \textbf{Location:} One of the arenas (apartment) and its surroundings. The apartment is in its normal state. Part of the test is performed outside the arena in a public space.
   \item \textbf{Start:} The robot starts waiting inside the arena.
-  \item \textbf{Car:} The car is any landmark chosen (but \emph{not} announced) beforehand outside the arena. Several bags (see \refsec{rule:scenario_objects}) with groceries are located where the car is parked. 
+  \item \textbf{Car:} The car is any landmark chosen (but \emph{not} announced) beforehand outside the arena. Several bags (see \refsec{rule:scenario_objects}) with groceries are located where the car is parked.
   \item \textbf{Doors:} All doors in the apartment are initially open.
-  \item \textbf{Operator:} A \quotes{professional} operator is selected by the TC to act as the operator of the robot. 
-  \item \textbf{Uncontrolled environment:} There are no restrictions on other people walking by or standing around throughout the complete task. 
+  \item \textbf{Operator:} A \quotes{professional} operator is selected by the TC to act as the operator of the robot.
+  \item \textbf{Uncontrolled environment:} There are no restrictions on other people walking by or standing around throughout the complete task.
 \end{enumerate}
 
 \subsection{Task}
@@ -37,8 +37,8 @@ The operator (the robot's owner) has a set of bags (and possibly other objects) 
   \item {[DSPL \& OPL]} \textbf{Bring the groceries in} \\
   The robot is asked to deliver a bag with groceries  to a specific location (e.g. \quotes{Take this bag to the kitchen table}).
   \begin{enumerate}
-    \item \textbf{Bag pick-up:} The robots gets the bag. For this there are several options to achieve this: 
-      \textbf{a)} Human puts bag in robot's hand, 
+    \item \textbf{Bag pick-up:} The robots gets the bag. For this there are several options to achieve this:
+      \textbf{a)} Human puts bag in robot's hand,
       \textbf{b)} robot picks up bag on floor,
       \textbf{c)} Robot takes bag from operator's hand
     \item \textbf{Bag delivery:} The robot delivers the bag to the instructed destination. It may place the bag on the floor or onto the placement location.\\
@@ -70,7 +70,7 @@ The operator (the robot's owner) has a set of bags (and possibly other objects) 
 \end{enumerate}
 
 \subsection{Obstacles}
-The robot will encounter some obstacles while navigating and the robot must deal and avoid or otherwise deal with the obstacle. 
+The robot will encounter some obstacles while navigating and the robot must deal and avoid or otherwise deal with the obstacle.
 The possible obstacles are:
 \begin{itemize}
   \item \textbf{3D Object:} A hard to see object that requires more than a laser scanner to be detected such as a bar table (wider at its top than on its bottom), rolling chair, lamp, etc.
@@ -81,7 +81,7 @@ The possible obstacles are:
 
   \item {[SSPL Only]} \textbf{\textit{Smart} obstacle:} A person blocking the robot's path to whom the robot may speak to and kindly ask to move away. When interacting with people, the robot must look at the person and make clear it is speaking with them.
 \end{itemize}
-%% Possible extensions: 
+%% Possible extensions:
 %% - DONE: allow the operator to tell for each item where it should go
 %% - At the destination room, there is a person waving, waiting for the robot to bring the items so (s)he can take them
 
@@ -91,7 +91,7 @@ The possible obstacles are:
   \begin{minipage}{0.65\textwidth}
   \item \textbf{Asking for passage:} The robot is allowed to (gently) ask individual people to step aside, but it is not allowed to blindly shout at groups of people.
 
-  \item \textbf{Bag handles:} The handles of the bag are always clear and standing up. See Figure \ref{fig:scenario_container_bag} in \refsec{rule:scenario_objects} for bag description. \footnotemark 
+  \item \textbf{Bag handles:} The handles of the bag are always clear and standing up. See Figure \ref{fig:scenario_container_bag} in \refsec{rule:scenario_objects} for bag description. \footnotemark
 
   \item \textbf{Bag pick-up:} If the robot can't handover the bag from the operator (i.e.~take it from the operator's hand) it may pick another bag from the surroundings. Additional bags might be either on the floor or on a table. It is expected the robot to actively try to grasp the bag from the operator's hand, and not passively waiting for the bag to be hanged on it. Shall the robot wait for the operator to hang the bag themself, the robot must clearly state it has detected the bag has been placed.
 
@@ -122,9 +122,9 @@ The possible obstacles are:
   \item \textbf{Disturbances from outside:} If a person from the audience (severely) interferes with the robot in a way that makes it impossible to solve the task, the team may repeat the test immediately.
 
   \item \textbf{Groceries:} Any kind of objects can be found lying around the location designated as the \textit{Car}, such as boxes, sacs, plastic bags, crates, and the groceries itself to give realism to the test. Regardless what objects are present, the robot shall carry an \textbf{official shopping bag} as described below and in \refsec{rule:scenario_objects}.
-  
+
   \item \textbf{Instruction:} The robot interacts with the operator, not the team.
-  
+
   \item \textbf{Natural walking:} The operator has to walk \quotes{naturally}, i.e., move forward facing forward. If not mentioned otherwise, the operator is not allowed to walk back, stand still, signal the robot or follow some re-calibration procedure.
 
   \item \textbf{Obstacle avoidance:} The robot will encounter several obstacles it must evade on its path between the car and the target destination.
@@ -135,12 +135,12 @@ The possible obstacles are:
 \end{enumerate}
 \footnotetext{This may change in the future. Then, a soft handle may be used which folds down}
 
-\subsection{Data recording}
-  Please record the following data (See \refsec{rule:datarecording}):
-\begin{itemize}
- \item Maps
- \item Plans
-\end{itemize}
+% \subsection{Data recording}
+%   Please record the following data (See \refsec{rule:datarecording}):
+% \begin{itemize}
+%  \item Maps
+%  \item Plans
+% \end{itemize}
 
 \subsection{Referee instructions}
 

--- a/tests/Restaurant.tex
+++ b/tests/Restaurant.tex
@@ -10,54 +10,54 @@ As this test is performed with 2 robots (2 teams, each with their own 1 robot) i
 
 \subsection{Setup}
 \begin{enumerate}
-	\item \textbf{Location:} A real restaurant fully equipped with a \quotes{Professional Barman} i.e. the operator and at least three tables with \quotes{Professional Clients}. 
+	\item \textbf{Location:} A real restaurant fully equipped with a \quotes{Professional Barman} i.e. the operator and at least three tables with \quotes{Professional Clients}.
 \end{enumerate}
 
 \subsection{Task}
 \begin{enumerate}
 	\item \textbf{Start:} The robot starts at a designated starting position. After the start signal is given, the robot may look around to keep an \textit{eye} on the tables.
-	  The location of the tables is not taught to the robot via some training phase. 
-	
-	\item \textbf{Calling:} A guest will ask for the robot's attention by waving \emph{and} calling it out using voice. 
+	  The location of the tables is not taught to the robot via some training phase.
+
+	\item \textbf{Calling:} A guest will ask for the robot's attention by waving \emph{and} calling it out using voice.
 	  The robot must state out loud that it has detected the call.
 	  % A robot must also indicate roughly where it has detected the call (e.g. \quotes{to my left})
-	  In case both robots notice the same call, the \textit{Professional Barman} will tell one of the robots to take the order. 
-	  The barman will say the robot's name followed by \quotes{Take the order} e.g. \quotes{R2D2, take the order}. 
-	  The other robot will simply have to wait for another call. 
-	  If the robot \textit{not} commanded to take the order still goes, it will be commanded to wait (e.g. \quotes{C3PO, Wait}). 
-	  In case the robot keeps going after that, the emergency button will be used to stop the robot. 
-	
-% 	\item \textbf{Parallel orders:} It may occur that two guests want to order something at the same time and thus wave at the same time. 
-% 	  The referees will arange these two guests such that each is clearly visible to (in front of) one of the robots. 
-	
+	  In case both robots notice the same call, the \textit{Professional Barman} will tell one of the robots to take the order.
+	  The barman will say the robot's name followed by \quotes{Take the order} e.g. \quotes{R2D2, take the order}.
+	  The other robot will simply have to wait for another call.
+	  If the robot \textit{not} commanded to take the order still goes, it will be commanded to wait (e.g. \quotes{C3PO, Wait}).
+	  In case the robot keeps going after that, the emergency button will be used to stop the robot.
+
+% 	\item \textbf{Parallel orders:} It may occur that two guests want to order something at the same time and thus wave at the same time.
+% 	  The referees will arange these two guests such that each is clearly visible to (in front of) one of the robots.
+
 	\item \textbf{Ordering}: The robot must ask the person what he or she wants to order. See Orders below for details about ordering.
-	\item \textbf{Avoiding random person:} At any time while going to any of the tables or to the \textit{Kitchen}, a person may step on the robot's path. 
+	\item \textbf{Avoiding random person:} At any time while going to any of the tables or to the \textit{Kitchen}, a person may step on the robot's path.
 	  It is expected of the robot to avoid that person or stop and wait for it to move away.
 
 	\item \textbf{Delivering phase:}
 	\begin{enumerate}
-		\item \textbf{Repeating the order:} Once again in the kitchen, the robot recites the orders for each table (e.g.~\textit{\quotes{Hamburger with fries for table A and Orange juice for table B}}, to the \textit{Professional Barman}. 
+		\item \textbf{Repeating the order:} Once again in the kitchen, the robot recites the orders for each table (e.g.~\textit{\quotes{Hamburger with fries for table A and Orange juice for table B}}, to the \textit{Professional Barman}.
 		  The \textit{Professional Barman} will serve the order and place it into a tray on the Kitchen-bar.
 		  If the barman cannot understand the order that the robot repeats, he cannot hand out the order and no points can be awarded for reciting the order.
 
-		\item \textbf{Grabbing a beverage:} The robot must grab a can of the appropriate drink from a set of cans on the Kitchen-bar. 
+		\item \textbf{Grabbing a beverage:} The robot must grab a can of the appropriate drink from a set of cans on the Kitchen-bar.
 
-		\item \textbf{Grabbing a combo:}  The robot must carry a tray with the ordering from the kitchen-bar. 
+		\item \textbf{Grabbing a combo:}  The robot must carry a tray with the ordering from the kitchen-bar.
 		Teams must indicate beforehand whether the robot is able to grasp the plate itself, whether it needs a tray or whether the plate needs to be handed to the robot.
-		
-		\item \textbf{Delivery:} The robot must place the order on the table. 
-		If the robot is not able to do this, the robot is allowed to hand over the order, but the client is not allowed to shift his/her chair or stand up. 
-		The robot must help the client, not the other way around. 
+
+		\item \textbf{Delivery:} The robot must place the order on the table.
+		If the robot is not able to do this, the robot is allowed to hand over the order, but the client is not allowed to shift his/her chair or stand up.
+		The robot must help the client, not the other way around.
 	\end{enumerate}
-	
+
 	\item \textbf{Next customer, please:} When the robot is in the kitchen, the \textit{Professional Barman} will ask the robot to either find a new client to serve or to stop the test.
-	The barman will either tell the robot \quotes{R2D2, Wait} to make it wait for another client or \quotes{R2D2, Stop the test} to end the test for that robot. 
+	The barman will either tell the robot \quotes{R2D2, Wait} to make it wait for another client or \quotes{R2D2, Stop the test} to end the test for that robot.
 \end{enumerate}
 
 \textbf{Orders:} The menu offers Beverages and Combos. An order may be a Beverage or Combo. Some guest(s) will order a Combo while another will order a Beverage.
-  A Combo is a combination of two of the food items from the set of objects \ref{rule:scenario_objects}, e.g. \quotes{noodles with peanuts} or \quotes{noodles and peanuts}. 
+  A Combo is a combination of two of the food items from the set of objects \ref{rule:scenario_objects}, e.g. \quotes{noodles with peanuts} or \quotes{noodles and peanuts}.
   Guests also prefer to state their order in a natural way, as they would in a restaurant operated by humans.
-  
+
 \begin{figure}[tbp]
 	\centering
 	\includegraphics[width=0.5\columnwidth]{images/restaurant.png}
@@ -76,23 +76,23 @@ As this test is performed with 2 robots (2 teams, each with their own 1 robot) i
 
 	\item \textbf{Order:} The way the user provides information to the robot is up to the robot's team. A natural interaction is preferred.
 
-	\item \textbf{Location:} This test can be arranged in any real restaurant or shopping mall. If this is not possible, the test can be conducted in an arbitrary room containing the appropriate locations. 
-	  The only requirement is that this room is not part of the arena and that the teams do not know the room beforehand. 
-	  The exact location, including the object and delivery locations, will be defined by the technical committee on site (and in corporation with the local organization). 
+	\item \textbf{Location:} This test can be arranged in any real restaurant or shopping mall. If this is not possible, the test can be conducted in an arbitrary room containing the appropriate locations.
+	  The only requirement is that this room is not part of the arena and that the teams do not know the room beforehand.
+	  The exact location, including the object and delivery locations, will be defined by the technical committee on site (and in corporation with the local organization).
 	  In addition, to avoid unnecessary time investment for navigation, the distances between tables and the \quotes{Kitchen Bar} will be minimal.
 
 	\item \textbf{Disturbances from outside:} If a person from the audience (severely) interferes with the robot in a way that makes it impossible to solve the task, the teams may repeat the test immediately.
 
-	\item \textbf{Learning tables:} Of course, it can only be sure that a robot correctly remembered where an order is suppposed to be delivered when it is able to go there after grabbing the order. 
-	
-	\item \textbf{Instruction:} The robot interacts with the operators, not the team. That is, the team is only allowed to (very!) briefly instruct the \textit{Professional Barman} 
-	\begin{itemize} 
+	\item \textbf{Learning tables:} Of course, it can only be sure that a robot correctly remembered where an order is suppposed to be delivered when it is able to go there after grabbing the order.
+
+	\item \textbf{Instruction:} The robot interacts with the operators, not the team. That is, the team is only allowed to (very!) briefly instruct the \textit{Professional Barman}
+	\begin{itemize}
 		\item How to the tell the robot the order has been served
 	\end{itemize}
 	It is not allowed to the team to instruct the clients on how to get robot's attention. It shall be done in a natural way like when interacting with a human waiter.
 
-	\item \textbf{Kitchen-bar:} The \textit{Kitchen-bar} will be a table located at the restaurant's kitchen, next to the place where the robot started. 
-	The robot may ask on which side of the robot the Kitchen-bar is, e.g. on its left or right side. It may ask this at any time, but it is better if the robot infers this itself. 
+	\item \textbf{Kitchen-bar:} The \textit{Kitchen-bar} will be a table located at the restaurant's kitchen, next to the place where the robot started.
+	The robot may ask on which side of the robot the Kitchen-bar is, e.g. on its left or right side. It may ask this at any time, but it is better if the robot infers this itself.
 	It has the following setup.
 	\begin{itemize}
 		\item \textbf{Barman:} A \textit{Professional Barman} (member of the TC) will be at the other side of the Kitchen-bar to take the order provided by the robot and serve it in the official tray.
@@ -101,34 +101,34 @@ As this test is performed with 2 robots (2 teams, each with their own 1 robot) i
 
 \end{itemize}
 
-\subsection{Data recording}
-  Please record the following data (See \refsec{rule:datarecording}):
-  \begin{itemize}
-   \item Audio
-   \item Commands
-   \item Mapping data
-   \item Images
-   \item Plans
-  \end{itemize}
+% \subsection{Data recording}
+%   Please record the following data (See \refsec{rule:datarecording}):
+%   \begin{itemize}
+%    \item Audio
+%    \item Commands
+%    \item Mapping data
+%    \item Images
+%    \item Plans
+%   \end{itemize}
 
 \subsubsection{Referee instructions}
 
 The referee needs to
 \begin{itemize}
-  \item Prepare orders for each client in advance, so that there can be no confusion. These orders must also be available at the kitchen. 
+  \item Prepare orders for each client in advance, so that there can be no confusion. These orders must also be available at the kitchen.
 \end{itemize}
 
 % \subsubsection{OC instructions}
 
 % \textbf{2 hours before the test}
 % \begin{itemize}
-% \item 
-% \item 
+% \item
+% \item
 % \end{itemize}
 % \textbf{During the test}
 % \begin{itemize}
-% \item 
-% \item 
+% \item
+% \item
 % \end{itemize}
 
 \newpage

--- a/tests/SPR.tex
+++ b/tests/SPR.tex
@@ -8,7 +8,7 @@ This test focuses on human detection, sound localization, speech recognition, an
 \begin{enumerate}
     \item \textbf{Location:} One room of the arena is used for this test\footnote{This test may also be held outside the arena}.
     \item \textbf{Crowd:} There is a crowd of 5 to 10 people in the designated room. People may be standing, sitting, lying, and in any pose.
-    \item \textbf{Doors:} All doors of the apartment are open, except for the entry door. 
+    \item \textbf{Doors:} All doors of the apartment are open, except for the entry door.
 \end{enumerate}
 
 \subsection{Task}
@@ -21,7 +21,7 @@ This test focuses on human detection, sound localization, speech recognition, an
     \footnotetext{It is possible to state the number of people whose gender couldn't be determined by the robot, therefore stating correctly the size of the crowd and, possibly, one of the gender groups.}
 
     \item \textbf{The riddle game:} Standing in front of the robot, the operator will ask 5 questions.\\
-    The robot must answer the question without asking confirmation. Questions will only be asked only once; no repetitions are allowed. 
+    The robot must answer the question without asking confirmation. Questions will only be asked only once; no repetitions are allowed.
 
     \newcounter{enumTempSPR}
     \setcounter{enumTempSPR}{\theenumi}
@@ -31,7 +31,7 @@ This test focuses on human detection, sound localization, speech recognition, an
         \item Directly answer the question without turning
         \item Turn towards the person and ask them to repeat the question
     \end{itemize}
-    This process is repeated with 10 (possibly) different people. 
+    This process is repeated with 10 (possibly) different people.
     The game will end when the 10th question has been made, following a similar distribution of questions as in the riddle game. The robot must answer the question without asking confirmation. Questions may be repeated once.
 
     \setcounter{enumi}{\theenumTempSPR}
@@ -41,9 +41,9 @@ This test focuses on human detection, sound localization, speech recognition, an
         \item Directly answer the question without turning
         \item Turn towards the person and ask them to repeat the question
     \end{itemize}
-    This process is repeated with 5 (possibly) different people. 
+    This process is repeated with 5 (possibly) different people.
     The game will end when the 5th question has been made, following the same distribution of questions as in the riddle game. The robot must answer the question without asking confirmation. Questions may be repeated once.
-    
+
     \item \textbf{Leave} The robot must leave the arena/test area after all questions have been asked or when instructed to do so.
 \end{enumerate}
 
@@ -74,13 +74,13 @@ This test focuses on human detection, sound localization, speech recognition, an
 	\label{fig:asrsetup}
 \end{figure}
 
-\subsection{Data recording}
-Please record the following data (See \refsec{rule:datarecording}):
-\begin{itemize}
-    \item Audio
-    \item Commands
-    \item Images
-\end{itemize}
+% \subsection{Data recording}
+% Please record the following data (See \refsec{rule:datarecording}):
+% \begin{itemize}
+%     \item Audio
+%     \item Commands
+%     \item Images
+% \end{itemize}
 
 \subsection{Referee instructions}
 

--- a/tests/SetATableTidyUp.tex
+++ b/tests/SetATableTidyUp.tex
@@ -18,7 +18,7 @@ This test focuses on HRI, semantic mapping, object perception and manipulation.
 %\begin{figure}[tbp]
 \begin{figure}[h!]
 	\centering
-	\subfloat[Typical arena]{\label{fig:sattu_table1}\includegraphics[height=46mm]{images/tablesetting1.jpg}} ~ 
+	\subfloat[Typical arena]{\label{fig:sattu_table1}\includegraphics[height=46mm]{images/tablesetting1.jpg}} ~
 	\subfloat[Typical objects]{\label{fig:sattu_table2}\includegraphics[height=46mm]{images/tablesetting2.jpg}}
 	\caption{Table settings: (a) occidental, and (b) Japanese.}
 	\label{fig:arena}
@@ -68,12 +68,12 @@ This test focuses on HRI, semantic mapping, object perception and manipulation.
 	\item \textbf{Task variation:} The team may provide the referees a written set of at least 2 options for serving a meal (e.g. cereal and milk, sandwiches, toasts, Coffee and bread, etc.). These options must be written as possible answers to the robot question (step~\ref{sattu:option} in section~\ref{sattu:task}). The correct execution of the specified variation should be clearly visible, e.g., choice of an object placed on the table.
 \end{enumerate}
 
-\subsection{Data recording}
-  Please record the following data (See \refsec{rule:datarecording}):
-  \begin{itemize}
-   \item Images of recognized objects
-   \item List of moved items
-  \end{itemize}
+% \subsection{Data recording}
+%   Please record the following data (See \refsec{rule:datarecording}):
+%   \begin{itemize}
+%    \item Images of recognized objects
+%    \item List of moved items
+%   \end{itemize}
 
 \subsection{Referee instructions}
 

--- a/tests/StoringGroceries.tex
+++ b/tests/StoringGroceries.tex
@@ -10,15 +10,15 @@ This test focuses on the detection and recognition of objects and their features
 \begin{minipage}{0.70\textwidth}
 	\subsection{Setup}
 	\begin{enumerate}
-		\item \textbf{Location:} One of the bookcases or cupboards in the apartment is used for this test, one where a table is near or can be put. 
+		\item \textbf{Location:} One of the bookcases or cupboards in the apartment is used for this test, one where a table is near or can be put.
 		\item \textbf{Start position:} The robot will start between the cupboard and the table in a random orientation, but facing towards the Cupboard.
 		\item \textbf{Cupboard:} The cupboard has 5 shelves between 0.30m and 1.80m from the ground and contains several objects (See \ref{rule:scenario_objects}).
 		\begin{itemize}
 		 	\item \textbf{Door:} The cupboard has a single door, which is closed initially.
 		 	This door encloses some of the objects, covering up to one half of the cupboard (e.g. the left or bottom half), as indicated by the hatched area in Figure \ref{fig:storing_groceries_shelf}.
-		\end{itemize} 
+		\end{itemize}
 		\item \textbf{Table:} A table near to the Cupboard has 10 objects (See \ref{rule:scenario_objects}). If not all objects fit on the table, they will be added during the test. The maximum distance between the Table and the Cupboard is 2m.
-		\item \textbf{Objects:} Objects in the Cupboard and on the Table can be known, alike, or unknown. Also, there will be more than one object on each shelf. 
+		\item \textbf{Objects:} Objects in the Cupboard and on the Table can be known, alike, or unknown. Also, there will be more than one object on each shelf.
 	\end{enumerate}
 \end{minipage}\hfill
 \begin{minipage}{0.25\textwidth}
@@ -37,7 +37,7 @@ This test focuses on the detection and recognition of objects and their features
 \begin{enumerate}
 	\item \textbf{Opening door:} The robot starts opening the Cupboard's door. If the robot is unable to open the door, it may ask the Referee to do it instead.
 	\item \textbf{Cupboard inspection:} The robot inspects the cupboard locating and categorizing existing groceries.
-	\item \textbf{Finding the table:} The robot turns around and locates the table.  
+	\item \textbf{Finding the table:} The robot turns around and locates the table.
 	\item \textbf{Table inspection:} The robot approaches the table starts analyzing the newly bought groceries (i.e. objects).
 	\item \textbf{Moving objects:} The robot chooses which object to move first from the Table to the Cupboard, allocating similar objects all together.
 	\begin{itemize}
@@ -46,7 +46,7 @@ This test focuses on the detection and recognition of objects and their features
 		\item If the Cupboard has no similar object, the robot must clearly state its decision on how to solve the problem. For instance, the robot can define a place for the newly found Category (e.g. Food was found but there is no other food in the cupboard), or group all new objects together (e.g. placing all Unknown objects together).
 	\end{itemize}
 
-	\textbf{Note:} Either before or after grasping an object the robot may announce the name of the object found. 
+	\textbf{Note:} Either before or after grasping an object the robot may announce the name of the object found.
 	\item \textbf{Repeat:} This repeats until the time is up or all groceries are stored.
 \end{enumerate}
 
@@ -54,7 +54,7 @@ This test focuses on the detection and recognition of objects and their features
 \begin{enumerate}
 	\item \textbf{Bypassing Manipulation:} Bypassing object manipulation via the CONTINUE rule (Section \refsec{rule:asrcontinue}) is not allowed during this test.
 	\item \textbf{No setup:} There is no setup time.
-	\item \textbf{Startup:} The robot can be started with a simple voice command or via a start button (Section \refsec{rule:start_signal}). 
+	\item \textbf{Startup:} The robot can be started with a simple voice command or via a start button (Section \refsec{rule:start_signal}).
 	\item \textbf{Single try:} The robot must be able to start from the first attempt. There is no restart for this test. If the robot is unable to start it must be removed immediately.
 	\item \textbf{Collisions:} Slightly touching the cupboard is tolerated (but not advised). Crushing objects or any other form of a major collision terminates the test immediately (Section \refsec{rule:safetyfirst}).
 	\item \textbf{Recognition report:} Robots must create a PDF report file including
@@ -73,22 +73,22 @@ This test focuses on the detection and recognition of objects and their features
 
 		\textbf{Remark:} False positives in the report (labeling an object which is not an object but e.g. the edge of the shelf) are penalized.
 
-		\textbf{Unknown objects:} A significant amount of objects are unknown objects. A correct label for these may be constituted by: 
+		\textbf{Unknown objects:} A significant amount of objects are unknown objects. A correct label for these may be constituted by:
 		\begin{itemize}
 			\item Simply labeling those as \quotes{Unknown} as opposed to wrongly applying a label from the known or alike objects
-			\item Labeling pairs of unknown objects of the same class with the same label (which may be e.g. \quotes{type\_X} for one pair and \quotes{relevant-feature\_Y} for another). 
+			\item Labeling pairs of unknown objects of the same class with the same label (which may be e.g. \quotes{type\_X} for one pair and \quotes{relevant-feature\_Y} for another).
 			\item Labeling unknown objects with a new, sensible label for objects.
 	 	\end{itemize}
 
 	\item \textbf{Clear area:} The robot may assume that the direct vicinity of the cupboard and table are clear, and that the robot can move slightly backwards for its task.
 \end{enumerate}
 
-\subsection{Data recording}
-Please record the following data (See \refsec{rule:datarecording}):
-\begin{itemize}
-	\item Images
-	\item Plans
-\end{itemize}
+% \subsection{Data recording}
+% Please record the following data (See \refsec{rule:datarecording}):
+% \begin{itemize}
+% 	\item Images
+% 	\item Plans
+% \end{itemize}
 
 \subsection{OC instructions}
 
@@ -100,9 +100,9 @@ Please record the following data (See \refsec{rule:datarecording}):
 \subsection{Referee instructions}
 The referee needs to
 \begin{itemize}
-	\item Place the objects in the cupboard and a few of the same class on the table. New items can be placed when there is room or the robot asks for more objects. 
-	\item Close the door of the cupboard. 
-	\item Put objects on the table and the corresponding objects in the cupboard: 3 known objects, 2 alike and 5 unknown objects. 
+	\item Place the objects in the cupboard and a few of the same class on the table. New items can be placed when there is room or the robot asks for more objects.
+	\item Close the door of the cupboard.
+	\item Put objects on the table and the corresponding objects in the cupboard: 3 known objects, 2 alike and 5 unknown objects.
 \end{itemize}
 
 


### PR DESCRIPTION
Mentions to bonus for contributing with recorded data from test were commented out (not deleted) as agreed in the last meeting. The macro was also disabled to hid the entry in the scoresheets.

Also this patch trails many spaces at the end of line.