### PR TITLE
Added optional audio data recollectionfor GPSR, EEGPSR and SPR.

### DIFF
--- a/tests/EEGPSR.tex
+++ b/tests/EEGPSR.tex
@@ -116,6 +116,8 @@ This test particularly focuses on the following aspects:
 	\item Take the command and total time per team.
 \end{itemize}
 
+\subsection {Audio Data Recollection}
+Teams are encouraged to submit to the TC the audio data recorded during the test, specially that which was captured during speech recoginition. If so, teams are urged to provide it with annotation of what the user said and what was recognized.
 
 \newpage
 \subsection{Score sheet}

--- a/tests/EEGPSR.tex
+++ b/tests/EEGPSR.tex
@@ -117,7 +117,7 @@ This test particularly focuses on the following aspects:
 \end{itemize}
 
 \subsection {Audio Data Recollection}
-Teams are encouraged to submit to the TC the audio data recorded during the test, specially that which was captured during speech recoginition. If so, teams are urged to provide it with annotation of what the user said and what was recognized.
+Teams are encouraged to submit to the TC the audio data recorded during the test, specially that which was captured during speech recoginition. If so, teams are urged to provide it with annotation of what the user said and what was recognized. Audio files are expected to be mono, one per microphone (in the case array recordings), of a sample rate equal to or higher than 16 kHz, and with a sample size of at least 16 bits. Depending on the quality of the recordings and their annothations, an official certificate that formalizes these efforts may be provided to submitting teams.
 
 \newpage
 \subsection{Score sheet}

--- a/tests/GPSR.tex
+++ b/tests/GPSR.tex
@@ -75,7 +75,7 @@ This test particularly focuses on the following aspects:
 \end{itemize}
 
 \subsection {Audio Data Recollection}
-Teams are encouraged to submit to the TC the audio data recorded during the test, specially that which was captured during speech recoginition. If so, teams are urged to provide it with annotation of what the user said and what was recognized.
+Teams are encouraged to submit to the TC the audio data recorded during the test, specially that which was captured during speech recoginition. If so, teams are urged to provide it with annotation of what the user said and what was recognized. Audio files are expected to be mono, one per microphone (in the case array recordings), of a sample rate equal to or higher than 16 kHz, and with a sample size of at least 16 bits. Depending on the quality of the recordings and their annothations, an official certificate that formalizes these efforts may be provided to submitting teams.
 
 \newpage
 \subsection{Score sheet}

--- a/tests/GPSR.tex
+++ b/tests/GPSR.tex
@@ -74,6 +74,9 @@ This test particularly focuses on the following aspects:
 	\item Specify and announce the entrance and exit door
 \end{itemize}
 
+\subsection {Audio Data Recollection}
+Teams are encouraged to submit to the TC the audio data recorded during the test, specially that which was captured during speech recoginition. If so, teams are urged to provide it with annotation of what the user said and what was recognized.
+
 \newpage
 \subsection{Score sheet}
 \input{scoresheets/GPSR.tex}

--- a/tests/SPR.tex
+++ b/tests/SPR.tex
@@ -108,7 +108,7 @@ The referee needs to
 \end{itemize}
 
 \subsection {Audio Data Recollection}
-Teams are encouraged to submit to the TC the audio data recorded during the test, specially that which was captured during speech recoginition. If so, teams are urged to provide it with annotation of what the user said and what was recognized.
+Teams are encouraged to submit to the TC the audio data recorded during the test, specially that which was captured during speech recoginition. If so, teams are urged to provide it with annotation of what the user said and what was recognized. Audio files are expected to be mono, one per microphone (in the case array recordings), of a sample rate equal to or higher than 16 kHz, and with a sample size of at least 16 bits. Depending on the quality of the recordings and their annothations, an official certificate that formalizes these efforts may be provided to submitting teams.
 
 \newpage
 \subsection{Score sheet}

--- a/tests/SPR.tex
+++ b/tests/SPR.tex
@@ -107,6 +107,9 @@ The referee needs to
     \item When the test is held outside the arena, announce the (way)point through which the robot shall leave
 \end{itemize}
 
+\subsection {Audio Data Recollection}
+Teams are encouraged to submit to the TC the audio data recorded during the test, specially that which was captured during speech recoginition. If so, teams are urged to provide it with annotation of what the user said and what was recognized.
+
 \newpage
 \subsection{Score sheet}
 \input{scoresheets/SPR.tex}


### PR DESCRIPTION
Thanks to @kyordhel for removing the recollecting data from the whole rule book. However, as discussed in the meeting, it is of interest to recollect audio data for speech recognition. Since GPSR, EEGPSR, and SPR are the most speech-recognition-based tests, we are encouraging teams to submit their annotated data to the TC. No mentions of points is given, just "encouragement". It's very probable that teams won't do it, but it's a possibility.