### PR TITLE
Storing Groceries: Opening door score 50pts

### DIFF
--- a/scoresheets/StoringGroceries.tex
+++ b/scoresheets/StoringGroceries.tex
@@ -4,7 +4,7 @@ The robot must place the first object within the first 2 minutes (+1 minute if t
 
 \begin{scorelist}
 	\scoreheading{Opening the door}
-	\scoreitem{20}{Autonomously opening the door}
+	\scoreitem{50}{Autonomously opening the door}
 	% Total: 20
 
 	\scoreheading{Arranging objects}
@@ -24,7 +24,7 @@ The robot must place the first object within the first 2 minutes (+1 minute if t
 	% Total 250
 
 
-	\setTotalScore{220}
+	\setTotalScore{250}
 \end{scorelist}
 
 


### PR DESCRIPTION
Increase the number of points for door opening from 20 to 50 in Storing Groceries

So far no team is trying to open the door. Therefore, increasing scoring for it may sense.

We must keep in mind that **no more than 20 points** should be granted if we provide an **official door handle** (see #362).