### PR TITLE
Fixes discussed in the 2nd TC meeting

### DIFF
--- a/scoresheets/EEGPSR.tex
+++ b/scoresheets/EEGPSR.tex
@@ -1,10 +1,12 @@
-The maximum time for this test is 10 minutes.
+The maximum time for this test is 45 minutes. \\
+Total team time is 15 minutes, with 5 minutes to execute each command.
 %
 % MAURICIO 2017
 % Compact Scoresheet
 %
 \begin{scorelist}
-	\scoreheading{Getting instructions} % Max 30
+	% Max 30
+	\scoreheading{Getting instructions\footnotemark}
 	\scoreitem[3]{10}{Understanding the command on the $1^{st}$ attempt}
 	\scoreitem[3]{ 5}{Understanding the command on the $1^{st}$ attempt (Custom Operator)}
 
@@ -21,12 +23,14 @@ The maximum time for this test is 10 minutes.
 	\scoreitem{ 70}{Command Category I}
 	\scoreitem{100}{Command Category II/III}
 	\scoreitem{ 20}{Explain nature of error (regardless command execution)}
-	
+
 	% \scoreheading{Leave the arena}
 	% \scoreitem{10}{Leave the arena after successfully accomplishing a command}
 
 	\setTotalScore{300}
 \end{scorelist}
+
+\footnotetext{\textbf{Remark:} Points for command retrieval are only granted if the robot actively tries to solve the task.}
 
 % Local Variables:
 % TeX-master: "Rulebook"

--- a/scoresheets/GPSR.tex
+++ b/scoresheets/GPSR.tex
@@ -4,7 +4,7 @@ The maximum time for this test is 10 minutes.
 % Compact Scoresheet
 %
 \begin{scorelist}
-	\scoreheading{Getting instructions}
+	\scoreheading{Getting instructions\footnotemark}
 	\scoreitem[3]{10}{Understanding the command on the $1^{st}$ attempt}
 	\scoreitem[3]{ 5}{\small Understanding the command on the $1^{st}$ attempt (Custom Operator)}
 	\scoreitem[3]{ 1}{Understanding the command at a later attempt}
@@ -23,12 +23,14 @@ The maximum time for this test is 10 minutes.
 	\scoreitem{ 40}{Command Category I}
 	\scoreitem{ 80}{Command Category II}
 	\scoreitem{120}{Command Category III}
-	
+
 	\scoreheading{Leave the arena}
 	\scoreitem{10}{Leave the arena after successfully accomplishing a command}
 
 	\setTotalScore{250}
 \end{scorelist}
+
+\footnotetext{\textbf{Remark:} Points for command retrieval are only granted if the robot actively tries to solve the task.}
 
 %
 % MAURICIO 2017

--- a/scoresheets/PnG.tex
+++ b/scoresheets/PnG.tex
@@ -1,6 +1,8 @@
 The maximum time for this test is \textbf{10 minutes}.
 
 \begin{scorelist}
+	\scoreheading{Opening the dishwasher} %50 pts
+	\scoreitem{50}{Autonomously opening the dishwasher}
 
 	\scoreheading{Filling the dishwasher (direct)} %200 pts
 	\scoreitem[3]{40}{Safely placing a tableware item in the dishwasher's rack}
@@ -23,7 +25,7 @@ The maximum time for this test is \textbf{10 minutes}.
 	\scoreheading{Leave the arena} %10 pts
 	\scoreitem{10}{Autonomously leave the arena before the time elapses}
 
-	\setTotalScore{300}
+	\setTotalScore{350}
 \end{scorelist}
 
 % Local Variables:

--- a/scoresheets/StoringGroceries.tex
+++ b/scoresheets/StoringGroceries.tex
@@ -4,7 +4,7 @@ The robot must place the first object within the first 2 minutes (+1 minute if t
 
 \begin{scorelist}
 	\scoreheading{Opening the door}
-	\scoreitem{50}{Autonomously opening the door}
+	\scoreitem{35}{Autonomously opening the door}
 	% Total: 20
 
 	\scoreheading{Arranging objects}
@@ -24,7 +24,7 @@ The robot must place the first object within the first 2 minutes (+1 minute if t
 	% Total 250
 
 
-	\setTotalScore{250}
+	\setTotalScore{235}
 \end{scorelist}
 
 

--- a/tests/EEGPSR.tex
+++ b/tests/EEGPSR.tex
@@ -47,7 +47,7 @@ This test particularly focuses on the following aspects:
 
 		\item \textbf{Category III: Objects.} The given commands focuses interacting with objects. Tasks in this category involve setting up a table, describe the objects placed on a table or shelf, and deliver objects that match a description or are located inside a cupboard or drawer.
 	\end{enumerate}
-		
+
 	The robot can work on at most \eegpsrMaxCmd commands within each of the following scenarios randomly chosen by the referee: \\
 
 	\begin{itemize}
@@ -72,16 +72,15 @@ This test particularly focuses on the following aspects:
 \label{sec:eegpsr-remarks}
 \begin{enumerate}
 	\item \textbf{CONTINUE rule:} Teams are able to use the CONTINUE rule in this test, with all the standard penalties it involves as described in section \refsec{rule:continue}.
-	%The CONTINUE rule can only be used with the custom operator (e.g. both penalties of custom speaker and CONTINUE rule will be applied). 
-	\\
+	%The CONTINUE rule can only be used with the custom operator (e.g. both penalties of custom speaker and CONTINUE rule will be applied).
 
-	\item \textbf{Number of Teams and Scheduling:} In each test slot, \eegpsrTeams teams may be competing in the arena concurrently. The robots will be tested in an interleaved fashion: The robots will retrieve commands and execute the task one after the other. As stated above, each robot will have a maximum amount of \eegpsrMaxCmdTime minutes per command (including time for retrieving the command and executing it). \\
-	
-	\item \textbf{Returning to designated position:} To facilitate a fluent and untroubled performance of the robots, they must return (or being returned) to their designated position before the \eegpsrMaxCmdTime minutes command time elapses. \textbf{If a robot moves from its designated position while another robot is working on a command, it must be immediately disabled} and moved to its designated position. If a restart is still available to the team, it can be restarted at its designated position. \\
+	\item \textbf{Number of Teams and Scheduling:} In each test slot, \eegpsrTeams teams may be competing in the arena concurrently. The robots will be tested in an interleaved fashion: The robots will retrieve commands and execute the task one after the other. As stated above, each robot will have a maximum amount of \eegpsrMaxCmdTime minutes per command (including time for retrieving the command and executing it).
 
-	\item \textbf{Referees:} Since the score system in this test involves a subjective evaluation of the robot's behavior, the referees are EC/TC members. One referee is assigned to each team to judge performance, to measure the time for working on a command, and to keep track of the overall operating time of the robot. \\
+	\item \textbf{Returning to designated position:} To facilitate a fluent and untroubled performance of the robots, they must return (or being returned) to their designated position before the \eegpsrMaxCmdTime minutes command time elapses. \textbf{If a robot moves from its designated position while another robot is working on a command, it must be immediately disabled} and moved to its designated position. If a restart is still available to the team, it can be restarted at its designated position.
 
-	\item \textbf{Category selection:} For every of the three commands given to the robot, the team chooses the desired command category.\\
+	\item \textbf{Referees:} Since the score system in this test involves a subjective evaluation of the robot's behavior, the referees are EC/TC members. One referee is assigned to each team to judge performance, to measure the time for working on a command, and to keep track of the overall operating time of the robot.
+
+	\item \textbf{Category selection:} For every of the three commands given to the robot, the team chooses the desired command category.
 
 	\item \textbf{Operator:}
 	\begin{itemize}
@@ -89,20 +88,24 @@ This test particularly focuses on the following aspects:
 		\item If the robot appears to consistently not be able to understand the operator, the referees ask the team to apply the CONTINUE rule (\refsec{rule:asrcontinue}).
 	\end{itemize}
 
-	\item \textbf{Inoperative robots:} If a robot gets stuck while trying to accomplish a task during a reasonable amount of time (e.g.~30 seconds), the referee may ask the team to move back the robot to its designated position, proceeding with the next robot. \\
+	\item \textbf{Inoperative robots:} If a robot gets stuck while trying to accomplish a task during a reasonable amount of time (e.g.~30 seconds), the referee may ask the team to move back the robot to its designated position, proceeding with the next robot.
 
-	\item \textbf{Restart:} Robots will be restarted at their designated position (starting outside the arena is prohibited). If a robot requires a restart, the referee will proceed with the next robot.\\
+	\item \textbf{Restart:} Robots will be restarted at their designated position (starting outside the arena is prohibited). If a robot requires a restart, the referee will proceed with the next robot.
 
-	\item \textbf{Changing/Charging batteries:} The team may install a charging station at the designated position of the robot, if it does not hinder the other robots. However, the robot must connect itself with the charging station after carrying out a command. Changing batteries or manually connecting the robot with the charging station is allowed during a restart. \\
+	\item \textbf{Changing/Charging batteries:} The team may install a charging station at the designated position of the robot, if it does not hinder the other robots. However, the robot must connect itself with the charging station after carrying out a command. Changing batteries or manually connecting the robot with the charging station is allowed during a restart.
 
-	\item \textbf{Scoring:} Robots are scored by successfully performed ability and full command completion within time. 
+	\item \textbf{Retrieving the command:} The robot must show it has understood the given command by repeating the command (i.e.~stating all the required information to accomplish the task).
+	\\
+	\textit{Note:} Referees must have sufficient evidence proving the robot is actively trying to execute the commanded tasks to score. Robots skipping command execution will not receive points for understanding the command.
+
+	\item \textbf{Scoring:} Robots are scored by successfully performed ability and full command completion within time.
 \end{enumerate}
 
 \subsection{OC instructions}
 \textbf{2h before test:}
 \begin{itemize}
-	\item Specify and announce the entrance/exit door for each robot. 
-	\item Specify and announce the waiting position for each robot. 
+	\item Specify and announce the entrance/exit door for each robot.
+	\item Specify and announce the waiting position for each robot.
 \end{itemize}
 \textbf{During the test:}
 \begin{itemize}
@@ -124,4 +127,4 @@ This test particularly focuses on the following aspects:
 % Local Variables:
 % TeX-master: "Rulebook"
 % End:
- 
+

--- a/tests/GPSR.tex
+++ b/tests/GPSR.tex
@@ -63,7 +63,9 @@ This test particularly focuses on the following aspects:
 		\item If the robot appears to consistently not be able to understand the operator, the referees ask the team to use a custom operator or bypassing speech recognition (\refsec{rule:asrcontinue}).
 	\end{itemize}
 
-	\item \textbf{Retrieving the command:} The robot must show it has understood the given command by repeating the command (i.e.~stating all the required information to accomplish the task.).
+	\item \textbf{Retrieving the command:} The robot must show it has understood the given command by repeating the command (i.e.~stating all the required information to accomplish the task).
+	\\
+	\textit{Note:} Referees must have sufficient evidence proving the robot is actively trying to execute the commanded tasks to score. Robots skipping command execution will not receive points for understanding the command.
 
 	\item \textbf{Incremental scoring:} Scoring depends on the category chosen by the team leader and the previous successfully accomplished command. Thereby, scoring for a second and third command depends on how well the robot solved (not understood) a first and second command respectively. Referees determine how well the command was accomplished and its impact on the incremental scoring of subsequent commands.
 \end{enumerate}

--- a/tests/PnG.tex
+++ b/tests/PnG.tex
@@ -53,6 +53,8 @@ This test focuses on object perception, manipulation, and planning.
 
 	\item \textbf{Dishwasher:} Is up to the team to decide whether the robot will place the objects in the dishwasher's rack or in the official tray. When using the tray, it should be loaded into the dishwasher.
 
+	\item \textbf{Dishwasher door:} Unless requested otherwise by the team, the dishwasher is open and with the racks pulled out by default. The team leader can, however, request the diswasher to be closed and score additional points for opening it. If the robot fails to open the door, it must clearly state it and request the referee to open it.
+
 	\item \textbf{Human-Robot Interaction:} The robot is allowed to
 	\begin{enumerate*}[label={\alph*)}]
 	\item indicate the location of the cloth or sponge,


### PR DESCRIPTION
Changes:

### Stage I
- GPSR:
  - Added remark to prevent point farming
- Storing Groceries:
  - Reduce points for door opening to 35 (was 50)

### Stage II
- EEGPSR:
  - Fixed test length in scoresheet
  - Added remark to prevent point farming

