### PR TITLE
Finals structure change to include a 4th and 3rd highest ranked.

### DIFF
--- a/tests/Finals.tex
+++ b/tests/Finals.tex
@@ -1,22 +1,19 @@
 \chapter{Finals}
 
-The competition ends with the Finals on the last day, where the five teams with the highest total score compete.
+The competition ends with the Finals on the last day, where the four teams with the highest total score compete.
 The \iterm{Finals} are conducted as a final open demonstration.
-% This demonstration does not have to be different from the other open demonstrations---Open Challenge and Demo Challenge. 
 This demonstration does not have to be different from the Open Challenge. 
 It does not have to be the same either.
 
-\section{Final Demonstration}
-In the final demonstration, every team qualified for the Finals can choose freely what to demonstrate. 
-The demonstration is evaluated by both a league-internal and a league-external jury.
+To avoid logistical issues during the last day of the competition, the \iterm{Finals} are divided into two sets of demonstrations.
+In the first set, the teams with the fourth and third highest score present their demonstrations, and are carried out in parallel between leagues.
+In the second set, the two teams with the highest score present their demonstrations in a serialized manner.
 
-\subsection{Task}
-The procedure for the demonstration and the timing of slots is as follows:
-\OpenDemonstrationTask{ten}{five}
+Even though each league has its own first, second and third place, the second set of presentations is meant to show the best of all leagues to the jury members as well as the audience and, thus, warrants a single schedule slot.
 
-\subsection{Evaluation and Score System}
-The demonstration is evaluated by both a league-internal and a league-external jury.
-The final score and ranking are determined by the two jury evaluations and by the previous performance (in Stages I and II) of the team.
+\section{Evaluating Juries for Final Demonstrations}
+Each set of final demonstrations is evaluated by a different combination of evaluating juries, here described.
+
 \begin{enumerate}
 \item\textbf{League-internal jury:} The league-internal jury is formed by the Executive Committee.
 The evaluation of the league-internal jury is based on the following criteria:
@@ -26,10 +23,6 @@ The evaluation of the league-internal jury is based on the following criteria:
   \item Relevance for @Home / Novelty of approaches %(evaluated by execs/TC)
   \item Presentation and performance in the finals.
   \end{compactenum}
-It is expected that teams present their scientific and technical contributions in both \iterm{team description paper} and the \iterm{RoboCup\char64Home Wiki}.
-In addition, finalist teams may provide a printed document to the jury (max 2 pages) that summarizes the demonstrated robot capabilities and contributions.  
-
-  The influence of the league-internal jury to the final ranking is \SI{25}{\percent}.
 
 \item \textbf{League-external jury:} The league-external jury consists of people not being involved in the RoboCup@Home league,
 but having a related background (not necessarily robotics).
@@ -43,11 +36,47 @@ The evaluation of the league-external jury is based on the following criteria:
   \item Difficulty and success of the performance
   \item Relevance / Usefulness for daily life
   \end{compactenum}
-  The influence of the league-external jury to the final ranking is \SI{25}{\percent}.
 
-\item \textbf{Previous performance:} \SI{50}{\percent} of the final score are determined by the team's previous performance during the competition, i.e., 
-the sum of points scored in Stage I and Stage II.
+\item\textbf{Teams-based jury:} The teams-based jury is formed by members of the league's teams.
+The evaluation of the teams-based jury is based on the following criteria:
+  \begin{compactenum}
+  \item Scientific contribution %(maybe taken from the OC)
+  \item Contribution to @Home %(evaluated by Execs/TC)
+  \item Relevance for @Home / Novelty of approaches %(evaluated by execs/TC)
+  \item Presentation and performance in the finals.
+  \end{compactenum}
 \end{enumerate}
+
+
+\section{Final Demonstration of 4th and 3rd Highest Scoring Teams}
+The demonstration is evaluated by one member of the league-internal jury, by one member of the league-external jury and by the complete team-based jury.
+The final score and ranking are determined by the jury evaluations and by the previous performance (in Stages I and II) of the team, in the following manner:
+
+\begin{enumerate}
+  \item The influence of the league-internal jury member to the final ranking is \SI{15}{\percent}.
+  \item The influence of the league-external jury member to the final ranking is \SI{15}{\percent}.
+  \item The influence of the teams-based jury to the final ranking is \SI{15}{\percent}.
+  \item The influence of the total sum of points scored by the team in Stage I and II is \SI{55}{\percent}.
+\end{enumerate}
+
+
+\section{Final Demonstration of 2nd and 1st Highest Scoring Teams}
+The demonstration is evaluated by the complete league-internal and the complete league-external jury.
+The final score and ranking are determined by the jury evaluations and by the previous performance (in Stages I and II) of the team, in the following manner:
+  
+\begin{enumerate}
+  \item The influence of the league-internal jury to the final ranking is \SI{25}{\percent}.
+  \item The influence of the league-external jury to the final ranking is \SI{25}{\percent}.
+  \item The influence of the total sum of points scored by the team in Stage I and II is \SI{50}{\percent}.
+\end{enumerate}
+  
+\section{Common Description of Final Demonstrations}
+Teams can choose freely what to demonstrate, however it is expected that teams present the scientific and technical contributions they submitted in both \iterm{team description paper} and the \iterm{RoboCup\char64Home Wiki}.
+In addition, teams may provide a printed document to the jury (max 2 pages) that summarizes the demonstrated robot capabilities and contributions.  
+
+\subsection{Task}
+The procedure for the demonstration and the timing of slots is as follows:
+\OpenDemonstrationTask{ten}{five}
 
 \OpenDemonstrationChanges
 


### PR DESCRIPTION
Changing the Finals structure to include a 4th and 3rd highest ranked team, and evaluated in parallel, as proposed in #359 .