### PR TITLE
Fix an issue with the penalty applied for not attending

### DIFF
--- a/general_rules/PenaltiesBonuses.tex
+++ b/general_rules/PenaltiesBonuses.tex
@@ -1,5 +1,5 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\newcommand{\penaltybig}{150~}
+\newcommand{\penaltybig}{50~}
 \newcommand{\penaltysmall}{50~}
 
 
@@ -9,22 +9,25 @@
 \begin{enumerate}
 	\item \textbf{Automatic schedule:} All teams are automatically scheduled for all tests.
 	\item \textbf{Announcement:} If a team cannot participate in a test (for any reason), the team leader has to announce this to the OC at least \timing{60 minutes} before the test slot begins.
-	\item \textbf{Penalties:} A team that is not present at the start position when their scheduled test starts, the team is not allowed to participate in the test anymore. If the team has not announced that it is not going to participate, it gets a penalty of \scoring{\penaltybig points}. 
+	\item \textbf{Penalties:} A team that is not present at the start position when their scheduled test starts, the team is not allowed to participate in the test anymore. If the team has not announced that it is not going to participate, it gets a penalty of \scoring{\penaltybig points}.
 \end{enumerate}
 
 \subsection{Extraordinary penalties}\label{rule:extraordinary_penalties}
 \begin{enumerate}
-	\item \textbf{Penalty for inoperative robots:} If a team starts a test, but it does not solve any of the partial tasks (and is obviously not trying to do so), a penalty of \scoring{\penaltysmall points} is handed out. The decision is made by the referees and the monitoring TC member.  
+	\item \textbf{Penalty for faking robots:} If a team starts a test, but it does not solve any of the partial tasks (and is obviously not trying to do so), a penalty of \scoring{\penaltybig points} is handed out. The decision is made by the referees and the monitoring TC member.
+
 	\item \textbf{Extra penalty for collision:} In case of major, (grossly) negligent collisions the \iaterm{Technical Committee}{TC} may disqualify the team for a test (the team receives \scoring{0 points}), or for the entire competition.
+
 	\item \textbf{Not showing up as referee or jury member:} If a team does not provide a referee or jury member (being at the arena on time), the team receives a penalty of \scoring{\penaltybig points}, and will be remembered for qualification decisions in future competitions.\\
 	Jury members missing a performance to evaluate are excluded from the jury, and the team is disqualified from the test (receives \scoring{0 points}).
+
 	\item \textbf{Modifying or altering standard platform robots:} If any unauthorized modification is found on a Standard Platform League robot, the responsible team will be immediately disqualified for the entire competition while also receiving a penalty of \scoring{\penaltybig points} in the overall score. This behavior will be remembered for qualification decisions in future competitions.\\
 \end{enumerate}
 
 \subsection{Bonus for outstanding performance}\label{rule:outstanding_performance}
 \begin{enumerate}
-	\item For every regular test in \iterm{Stage~I} and \iterm{Stage~II}, the @Home \iaterm{Technical Committee}{TC} can decide to give an extra bonus for \iterm{outstanding performance} of up to 10\% of the maximum test score. 
-	\item This is to reward teams that do more than what is needed to solely score points in a test but show innovative and general approaches to enhance the scope of @Home. 
+	\item For every regular test in \iterm{Stage~I} and \iterm{Stage~II}, the @Home \iaterm{Technical Committee}{TC} can decide to give an extra bonus for \iterm{outstanding performance} of up to 10\% of the maximum test score.
+	\item This is to reward teams that do more than what is needed to solely score points in a test but show innovative and general approaches to enhance the scope of @Home.
 	\item If a team thinks that it deserves this bonus, it should announce (and briefly explain) this to the \iaterm{Technical Committee}{TC} beforehand.
 	\item It is the decision of the \iaterm{Technical Committee}{TC} if (and to which degree) the bonus score is granted.
 \end{enumerate}


### PR DESCRIPTION
As discussed in #425, the penalty for inoperative robots were too high and inadequate, as well as the penalty for not attending.

There was a typo in the penalty macro (an additional 1) that was removed, reducing the penalty to just 50 points, applicable to all extraordinary penalties. Regarding inoperative robots , the rule referred to *it does not solve any of the partial tasks (and is obviously not trying to do so)* which means faking a test. Hence, the label was updated accordingly.

Fixes:
- All penalties of 150pts were reduced to 50pts (was a typo)
- Penalty for inoperative robots replaced with penalty for faking robots