### PR TITLE
Explicitely specifiy "announce bar location" in OC instructions

### DIFF
--- a/tests/CocktailParty.tex
+++ b/tests/CocktailParty.tex
@@ -89,7 +89,7 @@ The referees need to
 2h before test:
 \begin{itemize}
 	\item Specify and announce the rooms where the test takes place.
-	\item Specify and announce the location where the drinks are served.
+	\item Specify and announce the location where the drinks are served (i.e. bar location).
 \end{itemize}
 
 \newpage


### PR DESCRIPTION
Formerly, the test only instructed the O.C. to

> Specify and announce the location where the drinks are served

which although obvious, still raised concerns for not explicitly specify the drinks were served at the bar. This is now fixed.

This PR addresses and fixes #436