### PR TITLE
Add examples for alternate solution scoring in GPSR and EEGPSR

### DIFF
--- a/tests/EEGPSR_appendix.tex
+++ b/tests/EEGPSR_appendix.tex
@@ -102,7 +102,7 @@ Say the generated command is \textit{ask Joe to come here}, since the robot has 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Category III: Objects}
 \label{sec:eegpsr-category3-explained}
-Tasks from this category require handling objects into small or narrow spaces, opening doors and drawers, describing unknown objects, recognize objects from description, identify occluded objects and from the distance. 
+Tasks from this category require handling objects into small or narrow spaces, opening doors and drawers, describing unknown objects, recognize objects from description, identify occluded objects and from the distance.
 
 \subsubsection{Task examples}
 \begin{itemize}
@@ -202,3 +202,26 @@ Below some examples are presented. For each example command, one or more possibl
 		\item James is lying unconscious in the living room's floor.
 	\end{itemize}
 \end{itemize}
+
+\section{Bypassing commands and alternate solutions}
+The EEGPSR is a goal-driven test in which the final results has priority over how the command is executed.
+This adds several degrees of freedom to make a plan and execute a command accordingly with the robot's capabilities.
+
+For instance, consider the following command:
+
+\begin{center}
+\noindent\textit{Bring me a coke}
+\end{center}
+
+It is clear that the operator wants a coke and cares little about how the coke is retrieved. Now, let's say that the robot's manipulator is broken, so it won't be able to handle a coke. In this case, several scenarios become evident:
+
+\begin{itemize}
+	\item \textbf{Skipping command:} The robot says \quotes{I understood you want me to bring you a coke, but I cannot grasp objects, so I'll skip this command}. Since the robot is not executing the task, no score is given.
+
+	\item \textbf{Continue Rule:} The robot more or less reaches the position, fuzzily points at the object, and then requests to a human assistant to deliver the coke for it. In this case, the referee might grant up to $\frac{1}{3}$ of the points, if any.
+
+	\item \textbf{Requesting human assistance:} Taking advantage of the Continue Rule, the robot requests assistance from a human to grasp the object, requesting later to follow it. During the guiding phase, the robot actively tracks the human to the operator's position and supervises the delivery (e.g. telling it noticed the operator has received the coke). In this case, and regarding the execution of the tasks, the referee may grant a full score.
+
+	\item \textbf{Social alternative:} The robot looks for another person in the arena, finds them, and convinces them (or socially bribes them) to deliver a coke to the operator using natural language dialogs. In these rare cases, the referee would grant full score and even the team might request a bonus for outstanding performance.
+\end{itemize}
+

--- a/tests/EEGPSR_appendix.tex
+++ b/tests/EEGPSR_appendix.tex
@@ -222,6 +222,6 @@ It is clear that the operator wants a coke and cares little about how the coke i
 
 	\item \textbf{Requesting human assistance:} Taking advantage of the Continue Rule, the robot requests assistance from a human to grasp the object, requesting later to follow it. During the guiding phase, the robot actively tracks the human to the operator's position and supervises the delivery (e.g. telling it noticed the operator has received the coke). In this case, and regarding the execution of the tasks, the referee may grant a full score.
 
-	\item \textbf{Social alternative:} The robot looks for another person in the arena, finds them, and convinces them (or socially bribes them) to deliver a coke to the operator using natural language dialogs. In these rare cases, the referee would grant full score and even the team might request a bonus for outstanding performance.
+	\item \textbf{Social alternative:} The robot looks for another person in the arena, finds them, and convinces them (or socially bribes them) to deliver a coke to the operator using natural language dialogs. In these rare cases, the referee may grant a full score depending on the success of the interaction.
 \end{itemize}
 

--- a/tests/GPSR_appendix.tex
+++ b/tests/GPSR_appendix.tex
@@ -110,5 +110,5 @@ It is clear that the operator wants a coke and cares little about how the coke i
 
 	\item \textbf{Requesting human assistance:} Taking advantage of the Continue Rule, the robot requests assistance from a human to grasp the object, requesting later to follow it. During the guiding phase, the robot actively tracks the human to the operator's position and supervises the delivery (e.g. telling it noticed the operator has received the coke). In this case, and regarding the execution of the tasks, the referee may grant a full score.
 
-	\item \textbf{Social alternative:} The robot looks for another person in the arena, finds them, and convinces them (or socially bribes them) to deliver a coke to the operator using natural language dialogs. In these rare cases, the referee would grant full score and even the team might request a bonus for outstanding performance.
+	\item \textbf{Social alternative:} The robot looks for another person in the arena, finds them, and convinces them (or socially bribes them) to deliver a coke to the operator using natural language dialogs. In these rare cases, the referee may grant a full score depending on the success of the interaction.
 \end{itemize}

--- a/tests/GPSR_appendix.tex
+++ b/tests/GPSR_appendix.tex
@@ -43,13 +43,13 @@ Some examples are:
 
 \subsection{Category II:}
 \label{chap:gpsr-appendix-cat2}
-Tasks with a moderate difficulty degree. This category involves following a human, indoor navigation in crowded environments, manipulation and recognition of alike objects, find a calling person (waving or shouting), etc. 
+Tasks with a moderate difficulty degree. This category involves following a human, indoor navigation in crowded environments, manipulation and recognition of alike objects, find a calling person (waving or shouting), etc.
 
 Some examples are:
 \begin{itemize}
 	\item \textit{Tell me how many beverages in the shelf are red.}
 	\item \textit{Put the banana on the kitchen table.}
-	\item \textit{Count the waiving people in the livingroom.}
+	\item \textit{Count the waiving people in the living room.}
 	\item \textit{Follow Ana at the entrance.}
 	\item \textit{Tell me the name of the woman in the kitchen.}
 \end{itemize}
@@ -87,7 +87,28 @@ Some examples are:
 	\item \textit{Follow me and then go to the kitchen} (Operator takes the robot to the audience area).
 	\item \textit{Give me the left most object from the shelf.}
 	\item \textit{Count the drinks on the table.}
-	\item \textit{Tell me how many girls there are in the livingroom.}
+	\item \textit{Tell me how many girls there are in the living room.}
 \end{itemize}
 
 
+\section{Bypassing commands and alternate solutions}
+The General Purpose Service Robot is a goal-driven test in which the final results has priority over how the command is executed.
+This adds several degrees of freedom to make a plan and execute a command accordingly with the robot's capabilities.
+
+For instance, consider the following command:
+
+\begin{center}
+\noindent\textit{Bring me a coke}
+\end{center}
+
+It is clear that the operator wants a coke and cares little about how the coke is retrieved. Now, let's say that the robot's manipulator is broken, so it won't be able to handle a coke. In this case, several scenarios become evident:
+
+\begin{itemize}
+	\item \textbf{Skipping command:} The robot says \quotes{I understood you want me to bring you a coke, but I cannot grasp objects, so I'll skip this command}. Since the robot is not executing the task, no score is given.
+
+	\item \textbf{Continue Rule:} The robot more or less reaches the position, fuzzily points at the object, and then requests to a human assistant to deliver the coke for it. In this case, the referee might grant up to $\frac{1}{3}$ of the points, if any.
+
+	\item \textbf{Requesting human assistance:} Taking advantage of the Continue Rule, the robot requests assistance from a human to grasp the object, requesting later to follow it. During the guiding phase, the robot actively tracks the human to the operator's position and supervises the delivery (e.g. telling it noticed the operator has received the coke). In this case, and regarding the execution of the tasks, the referee may grant a full score.
+
+	\item \textbf{Social alternative:} The robot looks for another person in the arena, finds them, and convinces them (or socially bribes them) to deliver a coke to the operator using natural language dialogs. In these rare cases, the referee would grant full score and even the team might request a bonus for outstanding performance.
+\end{itemize}


### PR DESCRIPTION
This patch addresses #434 and specifies in the GPSR and EEGPSR appendices how work arrounds can be evaluated by a referee, centering attention in manipulation bypassing for SSPL.

> Bring me a coke

- **Skipping command:** The robot says "I understood you want me to bring you a coke, but I cannot grasp objects, so I'll skip this command". Since the robot is not executing the task, no score is given.
- **Continue Rule:** The robot more or less reaches the position, fuzzily points at the object, and then requests to a human assistant to deliver the coke for it. In this case, the referee might grant up to 1/3 of the points, if any.
- **Requesting human assistance:** Taking advantage of the Continue Rule, the robot requests assistance from a human to grasp the object, requesting later to follow it. During the guiding phase, the robot actively tracks the human to the operator's position and supervises the delivery (e.g. telling it noticed the operator has received the coke). In this case, and regarding the execution of the tasks, the referee may grant a full score.
- **Social alternative:** The robot looks for another person in the arena, finds them, and convinces them (or socially bribes them) to deliver a coke to the operator using natural language dialogs. In these rare cases, the referee would grant full score and even the team might request a bonus for outstanding performance.