### PR TITLE
Update rules for test moderation (LOC in charge)

### DIFF
--- a/general_rules/Procedure.tex
+++ b/general_rules/Procedure.tex
@@ -4,7 +4,7 @@
 \subsection{Safety First!}
 \label{rule:safetyfirst}
 \begin{enumerate}
-	\item \textbf{Emergency Stop:} At any time when operating the robot inside and outside the scenario the owners have to stop the robot immediately if there is a remote possibility of dangerous behavior towards people and/or objects. 
+	\item \textbf{Emergency Stop:} At any time when operating the robot inside and outside the scenario the owners have to stop the robot immediately if there is a remote possibility of dangerous behavior towards people and/or objects.
 	\item \textbf{Stopping on request:} If a referee, member of the Technical or Organizational committee, an Executive or Trustee of the federation tells the team to stop the robot, there will be no discussion and the robot has to be stopped \emph{immediately}.
 	\item \textbf{Penalties:} If the team does not comply, the team and its members will be excluded from the ongoing competition immediately by a decision of the RoboCup@Home \iaterm{Technical Committee}{TC}. 	Furthermore, the team and its members may be banned from future competitions for a period not less than a year by a decision of the RoboCup Federation Trustee Board.
 \end{enumerate}
@@ -15,26 +15,26 @@
 	\item \textbf{Regular Tests:} During a regular test, the maximum number of team members allowed inside the arena is \emph{one} (1). The only exceptions are tests that require for more team members in the arena.
 	\item \textbf{Setup:} During the setup of a test, the number of team members inside the arena is not limited.
 	% \item \textbf{Open Demonstrations:} During the \iterm{Open Challenge} \iterm{Demo Challenge}, and the \iaterm{final demonstration}{Finals}, the number of team members inside the arena is not limited.
-	\item \textbf{Open Demonstrations:} During the \iterm{Open Challenge}, and the \iaterm{final demonstration}{Finals}, the number of team members inside the arena is not limited. 
-	\item \textbf{Moderation:} During a regular test, one team member \emph{must} be available to host and comment the event (see \refsec{rule:moderator}).
+	\item \textbf{Open Demonstrations:} During the \iterm{Open Challenge}, and the \iaterm{final demonstration}{Finals}, the number of team members inside the arena is not limited.
+	\item \textbf{Moderation:} During a regular test, one team member \emph{must} be available to host and comment the test (see \refsec{rule:moderator}).
 \end{enumerate}
 
 \subsection{Fair play}
 \label{rule:fairplay}
 \iterm{Fair Play} and cooperative behavior is expected from all teams during the entire competition, in particular:
 \begin{itemize}
-	\item while evaluating other teams, 
-	\item while refereeing, and 
-	\item when having to interact with other teams' robots.  
+	\item while evaluating other teams,
+	\item while refereeing, and
+	\item when having to interact with other teams' robots.
 \end{itemize}
 This also includes:
 \begin{itemize}
-	\item not trying to cheat (e.g.~pretending autonomous behavior where there is none), 
-	\item not trying to exploit the rules (e.g.~not trying to solve the task but trying to score), and 
-	\item not trying to make other robots fail on purpose. 
-	\item not modifying robots in standard platforms. 
+	\item not trying to cheat (e.g.~pretending autonomous behavior where there is none),
+	\item not trying to exploit the rules (e.g.~not trying to solve the task but trying to score), and
+	\item not trying to make other robots fail on purpose.
+	\item not modifying robots in standard platforms.
 \end{itemize}
-Disregard of this rule can lead to penalties in the form of negative scores, and disqualification for a test or even for the entire competition. 
+Disregard of this rule can lead to penalties in the form of negative scores, and disqualification for a test or even for the entire competition.
 
 \subsection{Expected Robot's Behavior}
 Unless stated otherwise, it is expected that the robot always behave and react in the same way a polite and friendly human being would do. This applies also to how robots should address the problems in order to solve the assigned task, including addressing people, serving meals, storing the groceries, cleaning, arranging stuff, etc. As rule of thumb, ask your closest non-scientist neighbor to solve the task and take notes.
@@ -44,12 +44,12 @@ Keep in mind that one of the goals in RoboCup @Home is to have robots interactin
 
 \subsection{Robot Autonomy and Remote Control}
 \begin{enumerate}
-	\item \textbf{No touching:} During a test, the participants are not allowed to make contact with the robot(s), unless it is in a \quotes{natural} way and/or required by the test specification. 
+	\item \textbf{No touching:} During a test, the participants are not allowed to make contact with the robot(s), unless it is in a \quotes{natural} way and/or required by the test specification.
 	\item \textbf{Natural interaction:} The only allowed means to interact with the robot(s) are gestures and speech.
-	\item \textbf{Natural commands:} Only general instructions are allowed. 
+	\item \textbf{Natural commands:} Only general instructions are allowed.
 	Anything that resembles direct control is prohibited.
 	\item \textbf{Remote Control:} Remotely controlling the robot(s) is strictly prohibited. This also includes pressing buttons, or influencing sensors on purpose.
-	\item \textbf{Penalties:} Disregard of these rules can lead to penalties in the form of negative scores, and disqualification for a test or even for the entire competition. 
+	\item \textbf{Penalties:} Disregard of these rules can lead to penalties in the form of negative scores, and disqualification for a test or even for the entire competition.
 \end{enumerate}
 
 \subsection{Collisions}
@@ -59,7 +59,7 @@ Keep in mind that one of the goals in RoboCup @Home is to have robots interactin
 		\item It \emph{is} allowed however to \emph{functionally} touch an item with e.g.~the base.
 	\end{itemize}
 	The OC/TC/EC and the RoboCup Trustees all have the right to immediately stop a robot, and to disqualify a team for the duration of the competition, or longer, in case of \emph{dangerous} behavior. Furthermore, referees can recommend to disqualify a team in which case EC/TC decides.
-	\item \textbf{\iterm{Major collisions}:} If a robot crushes into something during a test, the robot is immediately stopped.	Additional penalties may apply. 
+	\item \textbf{\iterm{Major collisions}:} If a robot crushes into something during a test, the robot is immediately stopped.	Additional penalties may apply.
 	\item \textbf{Robot-Robot avoidance:} If two robots encounter each other, they both have to actively try to avoid the other robot.
 	\begin{enumerate}
 		\item A robot which is not going for a different route within a reasonable amount of time (e.g., \SI{30}{\second}) is removed.
@@ -81,20 +81,20 @@ Robots not obeying the rules are stopped and removed from the arena.
 \subsection{Start signal}
 \label{rule:start_signal}
 
-Different tests are started in different ways, according to what would make the most sense in the application setting. 
-Before a test starts, robots are waiting in a queue, sometimes accompanied by a team member. 
+Different tests are started in different ways, according to what would make the most sense in the application setting.
+Before a test starts, robots are waiting in a queue, sometimes accompanied by a team member.
 
 The various start methods are described below:
 \begin{enumerate}
-	\item \textbf{Door opening:} The robot is waiting behind the door, outside the arena (accompanied by a team member). The test attempt starts when a referee (not a team member) opens the door. 
-	\item \textbf{Start button:} If the robot is not able to automatically start after opening the door, the team may start the robot using a start button. 
+	\item \textbf{Door opening:} The robot is waiting behind the door, outside the arena (accompanied by a team member). The test attempt starts when a referee (not a team member) opens the door.
+	\item \textbf{Start button:} If the robot is not able to automatically start after opening the door, the team may start the robot using a start button.
 	\begin{enumerate}
 		\item Using a start button needs to be announced to the referees. It is the responsibility of the team to do so before the test starts.
 		\item There may be penalties for using a start button in some tests
 	\end{enumerate}
-    \item \textbf{Called by name:} A number of robots is waiting inside the arena, unaccompanied by team members. 
+    \item \textbf{Called by name:} A number of robots is waiting inside the arena, unaccompanied by team members.
 				      The referee approaches the robot, calls it by its name and gives the robot a command. e.g. \quotes{R2D2, start} or \quotes{C3PO, continue}.
-				      Other waiting robots must not respond. 
+				      Other waiting robots must not respond.
 \end{enumerate}
 
 
@@ -112,7 +112,7 @@ The various start methods are described below:
 \label{rule:gestures}
 Hand gestures may be used to control the robot in the following way:
 \begin{enumerate}
-	\item \textbf{Definition:} The teams define the hand gestures by themselves. 
+	\item \textbf{Definition:} The teams define the hand gestures by themselves.
 	\item \textbf{Approval:} Gestures need to be approved by the referees and TC member monitoring the test. Gestures should not involve more than the movement of both arms. This includes e.g.~expressions of sign language or pointing gestures.
 	\item \textbf{Instructing operators:} It is the responsibility of the team to instruct operators.
 	\begin{enumerate}
@@ -132,15 +132,15 @@ Hand gestures may be used to control the robot in the following way:
 % \refmark{}
 \begin{enumerate}
 	\item \textbf{Setup:} Unless stated otherwise, each test is monitored by two referees and one member of the \iaterm{Technical Committee}{TC}.
-	\item \textbf{Selection:} The two referees 
+	\item \textbf{Selection:} The two referees
 	\begin{itemize}
-		\item are chosen by EC/TC/OC, 
-		\item are announced together with the schedule for the test slot, 
+		\item are chosen by EC/TC/OC,
+		\item are announced together with the schedule for the test slot,
 		\item and have to referee all teams in that slot.
 		\item Referees may not be from one of the teams in the slot.
 	\end{itemize}
-	\item \textbf{Not showing up:} Not showing up for refereeing (on time) will result in a penalty (see \refsec{rule:extraordinary_penalties}). 
-	\item \textbf{TC monitoring:} The referee from the TC acts as a main referee. 
+	\item \textbf{Not showing up:} Not showing up for refereeing (on time) will result in a penalty (see \refsec{rule:extraordinary_penalties}).
+	\item \textbf{TC monitoring:} The referee from the TC acts as a main referee.
 	\item \textbf{Referee instructions:} Right before each test, referee instructions are conducted by the TC. The referees for all slots need to be present at the arena where the referee instructions are taking place.When and where referee instructions are taking place is announced together with the schedule for the slots.
 \end{enumerate}
 
@@ -151,7 +151,7 @@ Hand gestures may be used to control the robot in the following way:
 	\item \textbf{Default operator:} Unless stated otherwise, robots are operated by the monitoring TC member, a referee, or by a person selected by the TC.
 	\item \textbf{Fallback/custom operator:} If the robot fails to understand the command given by the default operator, the team may continue with a custom operator.
 	\begin{compactitem}
-		\item The custom operator may be any person chosen by the team (and willing to do so); including the referees or the monitoring TC member. 
+		\item The custom operator may be any person chosen by the team (and willing to do so); including the referees or the monitoring TC member.
 		\item A penalty may be involved when using a custom operator.
 	\end{compactitem}
 \end{enumerate}
@@ -160,17 +160,21 @@ Hand gestures may be used to control the robot in the following way:
 
 \subsection{Moderator}
 \label{rule:moderator}
+The LOC is responsible of organizing test moderation in the local language.
 \begin{enumerate}
-	\item \textbf{Providing a moderator:} For each regular test (i.e., not for the open demonstrations), all participating teams need to provide a team member as moderator for the duration of their performance. 
+	\item \textbf{Providing a moderator:}
+	Upon OC request, a participating team may have to provide a team member as moderator for a regular test (i.e., not for the open demonstrations).
+	Candidates have to be fluent in both, English and at least one of the main languages spoken by the audience.
 	\item \textbf{Responsibilities:} The moderators have to:
 	\begin{compactitem}
-		\item explain the rules of the test, 
-		\item comment on the performance of their team, 
-		\item not interfere with the performance, 
-		\item speak in English, 
+		\item explain the rules of the test,
+		\item comment on the performance of their team,
+		\item not interfere with the performance,
+		\item speak in English and the local language,
 		\item and obey the instructions by the monitoring TC member.
 	\end{compactitem}
-	\item \textbf{Competitive tests:} In competitive tests (tests in which two teams directly compete against each other), the moderation has to be done by the two teams together.
+	\item \textbf{Competitive tests:} In competitive tests (tests in which two teams directly compete against each other), the moderation has to be done or assessed by the two teams together.
+	\item \textbf{Not showing up:} Not showing up for moderation (on time) will result in a penalty (see \refsec{rule:extraordinary_penalties}).
 \end{enumerate}
 
 
@@ -179,8 +183,8 @@ Hand gestures may be used to control the robot in the following way:
 \begin{enumerate}
 	\item \textbf{Stage~I:} Unless stated otherwise, the time limit for each test in \iterm{Stage~I} is \timing{5 minutes}.
 	\item \textbf{Stage~II:} Unless stated otherwise, the time limit for each test in \iterm{Stage~II} is \timing{10 minutes}.
-	\item \textbf{Setup time:} Unless stated otherwise, all time specifications, e.g., setup time and time for instructing operators, are within the total test time. 
-	\item \textbf{Scores:} When the time is up, the team has to immediately remove their robot(s) from the arena; no more points can be scored. In special cases, the monitoring TC member may ask the team to continue the test for demonstration purposes (after time is up, points cannot be scored). 
+	\item \textbf{Setup time:} Unless stated otherwise, all time specifications, e.g., setup time and time for instructing operators, are within the total test time.
+	\item \textbf{Scores:} When the time is up, the team has to immediately remove their robot(s) from the arena; no more points can be scored. In special cases, the monitoring TC member may ask the team to continue the test for demonstration purposes (after time is up, points cannot be scored).
 \end{enumerate}
 
 
@@ -188,9 +192,9 @@ Hand gestures may be used to control the robot in the following way:
 \subsection{Restart}
 \label{rule:restart}
 \begin{enumerate}
-	\item \textbf{Stage 1} has no restarts but features multiple attempts at a test. 
-	If a robot fails during an attempt, the attempt ends. 
-	A robot has several (ideally 3, depending on available time in the schedule) attempts for each test. An attempt cannot be restarted. 
+	\item \textbf{Stage 1} has no restarts but features multiple attempts at a test.
+	If a robot fails during an attempt, the attempt ends.
+	A robot has several (ideally 3, depending on available time in the schedule) attempts for each test. An attempt cannot be restarted.
 	E.g. if a robot fails halfway through an attempt at the Help-me-Carry test, the attempt is over, the robot is moved out of the test area and may prepare for the remaining attempts at the test.
 
 	\item \textbf{Stage 2} does have restarts for all tests but the Open Challenge:
@@ -204,7 +208,7 @@ Hand gestures may be used to control the robot in the following way:
 			\item if the robot is doing nothing or nothing reasonable for \timing{one minute}, or
 			\item when the robot fails to understand a command for \timing{five times}, or
 			\item after a minor collision
-		\end{compactitem}  
+		\end{compactitem}
 	\end{enumerate}
 \end{enumerate}
 

--- a/general_rules/Procedure.tex
+++ b/general_rules/Procedure.tex
@@ -170,7 +170,7 @@ The LOC is responsible of organizing test moderation in the local language.
 		\item explain the rules of the test,
 		\item comment on the performance of their team,
 		\item not interfere with the performance,
-		\item speak in English and the local language,
+		\item speak in English and, preferably, the local language,
 		\item and obey the instructions by the monitoring TC member.
 	\end{compactitem}
 	\item \textbf{Competitive tests:} In competitive tests (tests in which two teams directly compete against each other), the moderation has to be done or assessed by the two teams together.

--- a/general_rules/Procedure.tex
+++ b/general_rules/Procedure.tex
@@ -164,7 +164,7 @@ The LOC is responsible of organizing test moderation in the local language.
 \begin{enumerate}
 	\item \textbf{Providing a moderator:}
 	Upon OC request, a participating team may have to provide a team member as moderator for a regular test (i.e., not for the open demonstrations).
-	Candidates have to be fluent in both, English and at least one of the main languages spoken by the audience.
+	Candidates have to be fluent in English and, preferably, at least one of the main languages spoken by the audience.
 	\item \textbf{Responsibilities:} The moderators have to:
 	\begin{compactitem}
 		\item explain the rules of the test,


### PR DESCRIPTION
Test moderation is delegated to LOC to organize. Teams won't moderate their own tests anymore, nor moderation will be in English. Instead:

- OC selects moderators from teams
- Moderators have to be proficient in English and the local language
- Not showing up for moderation carries up a penalty

**Remark:** I don't feel comfortable with the penalty for not showing up (line 177), but it was added to be consistent with the other rules. Worst case, the rule is there but not enforced. We might well remove it

This PR is partially based in #422 