### PR TITLE
Update committees and collaborators

### DIFF
--- a/citation.bib
+++ b/citation.bib
@@ -1,7 +1,7 @@
 @misc{rulebook_2018,
-  author =       {Loy van Beek AND Dirk Holz AND Mauricio Matamoros
-                  AND Caleb Rascon AND Sven Wachsmuth},
+  author =       {Matamoros, Mauricio AND Rascon, Caleb AND Hart, Justin AND
+                  Holz, Dirk AND van Beek, Loy },
   title =        {RoboCup@Home 2018: Rules and Regulations},
-  year =         2018,
+  year =         {2018},
   howpublished = {\url{http://www.robocupathome.org/rules/2018_rulebook.pdf}},
 }

--- a/introduction/Organization.tex
+++ b/introduction/Organization.tex
@@ -13,19 +13,16 @@ The \iaterm{Executive Committee}{EC} consists of members of the board of trustee
   \item Kai Chen (University of Science and Technology of China, China)
   \item Dirk Holz (University of Bonn, Germany)
   \item Caleb Rascon (Universidad Nacional Autonoma de Mexico, Mexico)
-  \item Sven Wachsmuth (Bielefeld University, Germany)
+  % \item Sven Wachsmuth (Bielefeld University, Germany)
 \end{itemize}
 
 \subsection{Technical Committee --- tc@robocupathome.org}
 \label{sec:tc}
 The \iaterm{Technical Committee}{TC} is responsible for the rules of each league. Members of the RoboCup@Home Technical Committee for \YEAR:
 \begin{itemize}
-  \item Loy Van Beek (Eindhoven University of Technology, The Netherlands)
-%  \item Jose Martinez-Carranza (National Institute for Astrophysics, Optics and Electronics, Mexico)
-  \item Kathrin Evers (Technische Universit{\"a}t Dresden, Germany)
-  \item Hideaki Nagano (Tokyo City University, Japan)
-%  \item Wei Shuai (University of Science and Technology of China, China)
-  \item Rodrigo Ventura (Institute for Systems and Robotics, Instituto Superior T{\'e}cnico, Portugal)
+  \item Justin Hart (University of Texas at Austin, USA)
+  \item Raphael Memmesheimer (University of Koblenz-Landau, Germany)
+  \item Sammy Pfeiffer (University of Technology Sydney, Australia)
 \end{itemize}
 The Technical Committee also includes the members of the Executive Committee.
 
@@ -34,11 +31,12 @@ The Technical Committee also includes the members of the Executive Committee.
 The \iaterm{Organizing Committee}{OC} is responsible for the organization of the competition. Members of the RoboCup@Home Organizing Committee for \YEAR:
 
 \begin{itemize}
-  \item Mauricio Matamoros (Universidad Nacional Autonoma de Mexico, Mexico)
+  \item[Chair] Mauricio Matamoros (University of Koblenz-Landau, Germany)
+  \item Alexander William Moriarty (Fetch Robotics, USA)
+  \item Fabrice Jumel (Université de Lyon; France)
   \item Francisco Javier Rodriguez Lera (University of Luxembourg, Luxembourg)
-  \item Raphael Memmesheimer (University of Koblenz, Germany)
-  \item Alexander William Moriarty (TBA, Bonn-Rhein-Sieg University; Germany)
   \item Jeffrey Too Chuan Tan (The University of Tokyo, Japan)
-%  \item Josemar Rodrigues de Souza (Bahia State University, Brazil)
-%  \item Ryuichi Ued (Chiba Institute of Technology, Japan)
+  \item Jesus Savage (Universidad Nacional Autónoma de México, Mexico)
+  \item Loy van Beek (Nobleo Technology, The Netherlands)
+  \item Luz Martínez (Universidad de Chile, Chile)
 \end{itemize}

--- a/introduction/Organization.tex
+++ b/introduction/Organization.tex
@@ -37,6 +37,5 @@ The \iaterm{Organizing Committee}{OC} is responsible for the organization of the
   \item Francisco Javier Rodriguez Lera (University of Luxembourg, Luxembourg)
   \item Jeffrey Too Chuan Tan (The University of Tokyo, Japan)
   \item Jesus Savage (Universidad Nacional Autónoma de México, Mexico)
-  \item Loy van Beek (Nobleo Technology, The Netherlands)
   \item Luz Martínez (Universidad de Chile, Chile)
 \end{itemize}

--- a/pages/acknowledgments.tex
+++ b/pages/acknowledgments.tex
@@ -69,7 +69,7 @@ We also like to thank all the people who contributed to the RoboCup@Home league 
 \begin{multicols}{2}%
 \footnotesize
 \noindent%
-Sebastian Borgsen (@semeyerz)\\
+Sebastian Meyer zu Borgsen (@semeyerz)\\
 Matthijs van der Burgh (@MatthijsBurgh)\\
 Remi Fabre (@RemiFabre)\\
 Tarik Kelestemur (@tkelestemur)\\

--- a/pages/acknowledgments.tex
+++ b/pages/acknowledgments.tex
@@ -41,18 +41,18 @@ We would like to thank the members of the technical committee who put up the rul
 \begin{multicols}{3}%
 \footnotesize
 \noindent%
-Loy van Beek\\
+
 % Kai Chen\\
 Justin Hart\\
 Luca Iocchi\\
-\columnbreak
-% Dirk Holz\\
 Mauricio Matamoros\\
+% Dirk Holz\\
+\columnbreak
 Raphael Memmesheimer\\
 Alexander Moriarty\\
-\columnbreak
-% Sammy Pfeiffer\\
 Caleb Rascon\\
+% Sammy Pfeiffer\\
+\columnbreak
 Komei Sugiura\\
 Sven Wachsmuth\\
 % Tijn van der Zant\\
@@ -69,6 +69,7 @@ We also like to thank all the people who contributed to the RoboCup@Home league 
 \begin{multicols}{2}%
 \footnotesize
 \noindent%
+Loy van Beek (@LoyVanBeek)\\
 Sebastian Meyer zu Borgsen (@semeyerz)\\
 Matthijs van der Burgh (@MatthijsBurgh)\\
 Remi Fabre (@RemiFabre)\\

--- a/pages/acknowledgments.tex
+++ b/pages/acknowledgments.tex
@@ -10,71 +10,79 @@
 
 \section*{About this rulebook}
 This is the official rulebook of the RoboCup@Home competition \YEAR.
-It has been written by the \YEAR ~RoboCup@Home Technical Committee (in alphabetical order): 
-% MAURICIO MATAMOROS @2018: Leaving only Execs as TC will be renewed
-% Loy van Beek,
-Kai Chen,
-Dirk Holz,
-% Justin Hart,
-% Mauricio Matamoros, 
-% Raphael Memmesheimer,
-% Hideaki Nagano,
-% Sammy Pfeiffer,
-Caleb Rascon, and
-Sven Wachsmuth.
+It has been written by the \YEAR ~RoboCup@Home Technical Committee with the special collaboration of (in alphabetical order):
+Mauricio Matamoros,
+and
+Loy van Beek.
+
+
 
 \section*{How to cite this rulebook}
 If you refer to RoboCup@Home and this rulebook in particular, please cite:
 
-Loy van Beek, Dirk Holz, Mauricio Matamoros, Caleb Rascon, and Sven Wachsmuth. 
-\quotes{Robocup@Home \YEAR: Rule and regulations,} 
-\url{http://www.robocupathome.org/rules/2017_rulebook.pdf}, \YEAR.
+Mauricio Matamoros, Caleb Rascon, Justin Hart, Dirk Holz, Kai Chen, and Loy van Beek.
+\quotes{Robocup@Home \YEAR: Rule and regulations,}
+\url{http://www.robocupathome.org/rules/2018_rulebook.pdf}, \YEAR.
 
-\verbatiminput{citation.bib}
+\begin{center}
+\begin{minipage}{0.8\textwidth}
+	\footnotesize%
+	\verbatiminput{citation.bib}
+\end{minipage}
+\end{center}
 
 \section*{Acknowledgments}
 \label{sec:acknowledgments}
-We would like to thank the members of the technical committee who put up the rules and the organizing committee who organizes the competition.  
+We would like to thank the members of the technical committee who put up the rules and the organizing committee who organizes the competition.
 
 ~\\\noindent People that have been working on this rulebook as member of one of the league's committees (in alphabetical order):
+\begin{center}
+\begin{minipage}{0.8\textwidth}
 \begin{multicols}{3}%
-% MAURICIO MATAMOROS @2018: Leaving only Trustees and Execs as TC will be renewed
+\footnotesize
 \noindent%
 Loy van Beek\\
-Kai Chen\\
+% Kai Chen\\
 Justin Hart\\
-\columnbreak
-Dirk Holz\\
 Luca Iocchi\\
+\columnbreak
+% Dirk Holz\\
 Mauricio Matamoros\\
 Raphael Memmesheimer\\
-Hideaki Nagano\\
+Alexander Moriarty\\
 \columnbreak
-Sammy Pfeiffer\\
+% Sammy Pfeiffer\\
 Caleb Rascon\\
 Komei Sugiura\\
 Sven Wachsmuth\\
-Tijn van der Zant\\
+% Tijn van der Zant\\
 \end{multicols}
+\end{minipage}
+\end{center}
 
-We also like to thank all the people who contributed to the RoboCup@Home league with their feedback and comments. 
+We also like to thank all the people who contributed to the RoboCup@Home league with their feedback and comments.
 
 % MAURICIO MATAMOROS @2018: Dummy names. Please addd the contributor username after the @
 ~\\\noindent People that have been working on this rulebook as member the league (in alphabetical order):
-\begin{multicols}{3}%
+\begin{center}
+\begin{minipage}{0.8\textwidth}
+\begin{multicols}{2}%
+\footnotesize
 \noindent%
-% Erika Mustermann\\%                @ Name place-holder (German)
-% Ivan Ivanovich Ivanov\\%           @ Name place-holder (Russian)
+Sebastian Borgsen (@semeyerz)\\
+Matthijs van der Burgh (@MatthijsBurgh)\\
+Remi Fabre (@RemiFabre)\\
+Tarik Kelestemur (@tkelestemur)\\
 \columnbreak%
-% Jan Jansen\\%                      @ Name place-holder (Dutch)
-% Jane Doe\\%                        @ Name place-holder (English)
-% Jean Dupont\\%                     @ Name place-holder (French)
-\columnbreak%
-% Juan Perez\\%                      @ Name place-holder (Mexican)
-% Li Si\\%                           @ Name place-holder (Chinesse)
-% Mario Rossi\\%                     @ Name place-holder (Italian)
-% Yamada Hanako\\%                   @ Name place-holder (Japanese)
+Johannes Kummert (@johaq)\\
+Florian Lier (@warp1337)\\
+Hiroyuki Okada (@okadahiroyuki)\\
+@AMR-\\
+@fibonatic\\
 \end{multicols}
+\end{minipage}
+\end{center}
+
 
 % Local Variables:
 % TeX-master: "../Rulebook"


### PR DESCRIPTION
This PR:
- Updates the list of people in committees (TC/OC/EC)
- Updates the citation.bib file (Authors sorted by contributions)
- Updates the names in the Acknowledgements section

Only active contributors were added in the TC list. Inactive people elected for the technical committee lost their rights to belong to the committee. Nonetheless, if I forgot someone (may have happened) please let me know.

@AMR-, @fibonatic, @johaq, @MatthijsBurgh, @okadahiroyuki, @RemiFabre, @semeyerz, @tkelestemur, @warp1337, please check your names.

This PR conflicts with #453 and must be applied BEFORE!