### PR TITLE
Add "anounce the robot's initial position" to OC tasks in GPSR

### DIFF
--- a/tests/GPSR.tex
+++ b/tests/GPSR.tex
@@ -74,6 +74,7 @@ This test particularly focuses on the following aspects:
 \textbf{2h before test:}
 \begin{itemize}
 	\item Specify and announce the entrance and exit door
+	\item Specify and announce the command retrieval point
 \end{itemize}
 
 \subsection {Audio Data Recollection}


### PR DESCRIPTION
For some reason, the entry was missing.