### PR TITLE
The TC now have the right to assign more than two slots per teams

### DIFF
--- a/general_rules/Organization.tex
+++ b/general_rules/Organization.tex
@@ -39,6 +39,7 @@ In case of having no considerable score deviation between a team advancing to th
 	The \iaterm{Organizing Committee}{OC} announces the schedule during the setup days (see Table \ref{tbl:schedule}).
 
 	\item \textbf{Slots:} The \iaterm{Organizing Committee}{OC} assigns at least two \iterm{test slots} of 5 minutes to each team in each block.
+   The maximum number of \iterm{tests slots} will be announced during setup days by the \iaterm{Technical Committee}{TC} based on the available time and the number of participating teams.
 	A team can solve any task during its test slot.
 	Remaining block time can be used to assign additional testing slots to interested teams.
 	Testing slots are randomly assigned to teams in each block.


### PR DESCRIPTION
Closes #509 

TC will determine if there is a need to assign more than two test slots per team.