### PR TITLE
 Adds "standard" to the legend "excluding penalties and bonuses"

### DIFF
--- a/setup/macros_score_sheets.tex
+++ b/setup/macros_score_sheets.tex
@@ -408,7 +408,7 @@
 	% set outstanding bonus counter to arbitrary value %%%%%%%%%%%%
 	\newcommand{\setOutstandingBonus}[1]%
 	{%
-		\setcounter{currOutstandingBonus}{##1}
+		\setcounter{currOutstandingBonus}{##1}%
 	}
 
 	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -498,7 +498,6 @@
 	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	% setup table %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-	% \par First column width: \@fcwidth\\
 	\vspace{0.8 em}%
 	\noindent%
 	\begin{tabularx}{\textwidth}{ @{}X @{}r *{\scorelistAttempts}{c}}
@@ -571,8 +570,6 @@
 	\scoreTotal
 
 	\end{tabularx}
-	% \endtabularx
-
 }
 \makeatother%
 

--- a/setup/macros_score_sheets.tex
+++ b/setup/macros_score_sheets.tex
@@ -431,7 +431,7 @@
 		\\%
 		\textbf{Total score~}%
 		\ifShortScoresheet{%
-			(excluding penalties and bonuses) &%
+			(excluding penalties and standard bonuses) &%
 			\textit{\thecurrTestScoreTotalWithoutBonus}%
 		}{%
 			&\textit{\thecurrTestScoreTotal}


### PR DESCRIPTION
Under the new schema, bonus points are normally added to the maximum total score. Hence, the legend in the rulebook should say "excluding penalties and standard bonuses" instead of "excluding penalties and bonuses" ("standard" word added).

This patch also removes unnecessary lines and linebreaks