### PR TITLE
Incentivize quality over quantity

### DIFF
--- a/general_rules/Organization.tex
+++ b/general_rules/Organization.tex
@@ -122,7 +122,8 @@ In case of having no considerable score deviation between a team advancing to th
 \label{rule:score_system}
 Each task has a main objective and a set of scoring bonuses.
 To score in a test, a team must successfully accomplish the main objective of the task; bonuses are not considered otherwise.
-Overall scoring is calculated as the sum of the maximum score obtained in each ability.
+
+The overall score is calculated as the sum of the maximum scores obtained in each thematic scenario of each stage. For example, if a team scores 500 in \textit{Clean Up [Housekeeper]}, 400 in \textit{Take Out the Garbage [Housekeeper]} and 800 in \textit{Farewell [Party Host]}, their total score is $max([500, 400]) + max([800]) = 1300$ for Stage I.
 
 The \iaterm{score system} has the following constrains
 \begin{enumerate}


### PR DESCRIPTION
This is one possible way to incentivize teams producing high-quality, reliable and excellent solutions rather than a scatter-gun approach of trying to solve every problem.

Teams will want to earn bonus rewards on a single problem, rather than doing the bare minimum across many many tasks.

This is related to the discussion in https://github.com/RoboCupAtHome/RuleBook/issues/508#issuecomment-459926511