### PR TITLE
Reduce breadth of rulebook

### DIFF
--- a/general_rules/Organization.tex
+++ b/general_rules/Organization.tex
@@ -29,6 +29,11 @@ The \iaterm{Housekeeper} scenario features tasks related to cleaning, organizing
 
 In case of having no considerable score deviation between a team advancing to the next stage and a team dropping out, the TC may announce additional teams advancing to the next stage.
 
+\subsection{Stage II for SSPL and DSPL}
+
+SSPL and DSPL teams may attempt Stage I tests in Stage II, in addition to any of the Stage II tests.
+
+As Stage I tasks have a maximum reward of 1000 points, if those tasks are used in Stage II, their rewards (and penalties) are doubled.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Schedule}


### PR DESCRIPTION
This is one possible way to reduce the breadth of the competition and ensure that teams are set up to succeed and look good.

A rule of this kind might be removed in 2020 or a future year when the league has reached the point that most teams are able to reliably achieve over 50% on at least half the Stage I tests.

This is related to the discussion in https://github.com/RoboCupAtHome/RuleBook/issues/508#issuecomment-459926511

Even if this particular proposal is not popular, I do want to raise attention to the need for setting teams up to succeed and look good to create a healthy, competitive and welcoming community, rather than every test needing to be a stretch goal.

A look at last year's results for standard platform leagues suggests that even achieving basic stage I competencies remains a challenge. It shouldn't be the case that hard-working and talented researchers from universities across the world are getting low or zero scores in many categories. This is perhaps caused by hardware limitations in the SPLs. e.g., Pepper's sensors are limited so that effective sensing in "real world" scenarios remains a difficult challenge.