### PR TITLE
Fix issue #597: Ambiguous scoring specification in Where is This

### DIFF
--- a/tasks/WhereIsThis.tex
+++ b/tasks/WhereIsThis.tex
@@ -4,7 +4,7 @@ The robot has to explain to people where they can find places in the arena (e.g.
 
 
 \subsection*{Main Goal}
-Give accurate directions or guide at least 5 people.
+Give accurate directions or guide at least 3 people.
 
 \noindent\textbf{Reward:} 300pts (100pts per direction/guidance).
 


### PR DESCRIPTION
### Change log
- Corrects typo in main goal scoring reward to 3 people (was 5).
