### PR TITLE
Fix object count in scoresheet of PnG Task (Clean the Table)

### DIFF
--- a/scoresheets/CleanTable.tex
+++ b/scoresheets/CleanTable.tex
@@ -3,15 +3,16 @@ The maximum time for this test is 10 minutes.
 \begin{scorelist}
 	\scoreheading{Main Goal}
 	\scoreitem{1000}{Place all tableware and cutlery inside the dishwasher}
-	\penaltyitem[7]{50}{Pointing at object}
-	\penaltyitem[7]{50}{Handover an object}
+	\penaltyitem[5]{50}{Pointing at object}
+	\penaltyitem[5]{50}{Handover an object}
 	\penaltyitem[3]{200}{Bypassing tableware storage}
-	\penaltyitem[3]{250}{Bypassing cutlery storage}
+	\penaltyitem[2]{250}{Bypassing cutlery storage}
 
 	\scoreheading{Bonus rewards}
 	\scoreitem{300}{Opening the dishwasher door}
 	\scoreitem{300}{Pulling out the dishwasher racks}
 	\scoreitem{300}{Placing the Cascade Pod inside the dishwasher}
+	\penaltyitem{100}{Handover or pointing at Cascade Pod}
 	\scoreitem{100}{Autonomously leaving the arena}
 
 	%\setTotalScore{1000}


### PR DESCRIPTION
Addresses #594 

### Change log:
- Number of penalties for handover/point set to 5 (was 7)
- Number of cutlery items set to 2 (was 3)
- Added penalty for handover/point-at cascadepod