### PR TITLE
Adds official add-ons for DSPL in a concise manner

### DIFF
--- a/general_rules/ExternalDevices.tex
+++ b/general_rules/ExternalDevices.tex
@@ -63,10 +63,10 @@ In the Domestic Standard Platform League, teams are allowed to attach the follow
 	\item One USB-powered IEEE 802.3ab (or newer) compliant device (Gigabit Ethernet Switch).
 \end{itemize}
 
-In all cases, the number of attached devices can never be more than three, and the sum of the linear dimensions of each device is limited to 15cm, excepting the speaker which is limited up to 30cm.
+In all cases, the number of attached devices can never be more than three, and the sum of the linear dimensions of each device is limited to 15cm, except for the speaker which is limited up to 30cm.
 
 Devices attached to the \iterm{OSL} must fit inside the TOYOTA HSR \iterm{Mounting Bracket} and not increase the dimensions of the robot.
-For this purpose, using short cables (no longer than 20cm) and and attaching the device to the OSL is advised.
+For this purpose, using short cables (no longer than 20cm) and attaching the device to the OSL is advised.
 We encourage teams to conceal such devices between the robot and the OSL.
 
 \noindent\textbf{Remark:} Please mind the appearance of the robots. Hanging wires and taped devices (e.g.~duct-tape) are \textbf{NOT} allowed.

--- a/general_rules/ExternalDevices.tex
+++ b/general_rules/ExternalDevices.tex
@@ -50,6 +50,27 @@ In the Domestic Standard Platform League, teams must use the \iaterm{Official St
 Any laptop fitting inside the TOYOTA HSR \iterm{Mounting Bracket} is allowed, regardless of its technical specification.
 All competing robots must have mounted an OSL, whether they use it or not, so all TOYOTA HSRs have the same load restrictions.
 
+\subsection{Authorized add-ons for DSPL}
+In the Domestic Standard Platform League, teams are allowed to attach the following devices to either the Toyota HSR or the \iterm{OSL}.
+
+\begin{itemize}
+	\item One USB audio-output device such as:
+	\begin{itemize}
+		\item USB power speaker.
+		\item Sound card (dongle).
+	\end{itemize}
+	\item One USB-powered IEEE 802.11ac (or newer) compliant device (Wi-Fi adapter).
+	\item One USB-powered IEEE 802.3ab (or newer) compliant device (Gigabit Ethernet Switch).
+\end{itemize}
+
+In all cases, the number of attached devices can never be more than three, and the sum of the linear dimensions of each device is limited to 15cm, excepting the speaker which is limited up to 30cm.
+
+Devices attached to the \iterm{OSL} must fit inside the TOYOTA HSR \iterm{Mounting Bracket} and not increase the dimensions of the robot.
+For this purpose, using short cables (no longer than 20cm) and and attaching the device to the OSL is advised.
+We encourage teams to conceal such devices between the robot and the OSL.
+
+\noindent\textbf{Remark:} Please mind the appearance of the robots. Hanging wires and taped devices (e.g.~duct-tape) are \textbf{NOT} allowed.
+
 
 % Local Variables:
 % TeX-master: "../Rulebook"


### PR DESCRIPTION
Allows:

- One USB audio-output device such as:
    - USB power speaker.
    - Sound card (dongle).
- Wi-Fi adapter (IEEE 802.11ac or newer).
- Gigabit Ethernet Switch (IEEE 802.3ab or newer)

Restrictions:
- Small (linear dimension sum up to 15cm).
- No loose wires.
- No visible devices.
- No tape

**Remark:** This summarizes and replaces #556 and #634 