### PR TITLE
Predefined score reduction (DeM) for bypassing manipulation in Serving Drinks

### DIFF
--- a/scoresheets/ServingDrinks.tex
+++ b/scoresheets/ServingDrinks.tex
@@ -3,6 +3,8 @@ The maximum time for this test is \textbf{5 minutes}.
 \begin{scorelist}
 	\scoreheading{Main Goal}
 	\scoreitem[3]{250}{Deliver a drink to a guest}
+	\penaltyitem[3]{75}{Each drink handed-over to the robot (bypass picking)}
+	\penaltyitem[3]{75}{Each drink taken by a guest (bypass drink handover)}
 	\penaltyitem[3]{100}{Each guest approaching to the robot to place order}
 	\penaltyitem[3]{50}{Each guest waving or calling the robot to place order}
 	\penaltyitem[2]{100}{Telling the robot which drink is unavailable}


### PR DESCRIPTION
Changes as follows

- Score reduction of 75pts (30%) for bypassing handover
- Score reduction of 75pts (30%) for bypassing pick
- Addresses #639