### PR TITLE
Balances penalties in P&G Clean the Table

### DIFF
--- a/scoresheets/CleanTable.tex
+++ b/scoresheets/CleanTable.tex
@@ -4,7 +4,7 @@ The maximum time for this test is 10 minutes.
 	\scoreheading{Main Goal}
 	\scoreitem{1000}{Place all tableware and cutlery inside the dishwasher}
 	\penaltyitem[5]{50}{Pointing at object}
-	\penaltyitem[5]{50}{Handover an object}
+	\penaltyitem[5]{150}{Handover an object}
 	\penaltyitem[3]{200}{Bypassing tableware storage}
 	\penaltyitem[2]{250}{Bypassing cutlery storage}
 
@@ -12,7 +12,8 @@ The maximum time for this test is 10 minutes.
 	\scoreitem{300}{Opening the dishwasher door}
 	\scoreitem{300}{Pulling out the dishwasher racks}
 	\scoreitem{300}{Placing the Cascade Pod inside the dishwasher}
-	\penaltyitem{100}{Handover or pointing at Cascade Pod}
+	\penaltyitem{100}{Pointing at the Cascade Pod}
+	\penaltyitem{200}{Handover the Cascade Pod}
 	\scoreitem{100}{Autonomously leaving the arena}
 
 	%\setTotalScore{1000}


### PR DESCRIPTION
Receiving an object (handover) makes the test considerably easier to solve. In contrast, pointing at an object only bypasses the recognition, not the grasping, which is challenging.

The penalties for pointing and receiving (handover) an object were adjusted as follows:

- Pointing at an object -50pts
- Handover an object -150pts (placing is almost trivial here)
- Addresses #639