### PR TITLE
Added partial scoring remark where appropriate

### DIFF
--- a/tasks/CleanUp.tex
+++ b/tasks/CleanUp.tex
@@ -27,6 +27,7 @@ Find all misplaced objects in a room and bring them to their predefined location
 
 \subsection*{Additional Rules and Remarks}
 \begin{enumerate}[nosep]
+	\item \textbf{Partial scoring:} The main task allows partial (per object) scoring.
 	\item \textbf{Objects:}
 	Objects can be anywhere, including the floor, seats, and on furniture.
 	All objects are clearly visible (i.e.~no occlusions) and can be:

--- a/tasks/FindMyMates.tex
+++ b/tasks/FindMyMates.tex
@@ -23,6 +23,7 @@ Report to the operator the description and location of at least two party guests
 
 \subsection*{Additional rules and remarks}
 \begin{enumerate}[nosep]
+	\item \textbf{Partial scoring:} The main task allows partial (per guest) scoring.
 	\item \textbf{Deus ex Machina:} Score reduction for requesting human assistance is applied per guest.
 	\begin{itemize}
 		\item -75 pts if a person has to wave the robot in order to be found

--- a/tasks/GPSR.tex
+++ b/tasks/GPSR.tex
@@ -39,6 +39,8 @@ Execute each of the 3 commands requested by the operator.
 % %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection*{Additional rules and remarks}
 \begin{enumerate}[nosep]
+	\item \textbf{Partial scoring:} The main task allows partial (per command) scoring.
+	
 	\item \textbf{Command Generator:} Tasks will be generated using the official \emph{GPSR Command Generator} available 2 months prior to the competition in the official repository.
 
 	\item \textbf{Naive Operators:} Optionally, commands can be issued by a \emph{Naive Operator}, i.e.~a person from the audience with no background on robotics. The referee gives the command to the \emph{Naive Operator}, who will then issue it to the robot (rephrasing is allowed). If the robot consistently fails to understand the naive operator (e.g.~3 times or more), teams can default to a custom operator.

--- a/tasks/HandMeThat.tex
+++ b/tasks/HandMeThat.tex
@@ -55,6 +55,8 @@ The robot identifies (touching or naming) each object at which the operator is p
 % %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection*{Additional rules and remarks}
 \begin{enumerate}[nosep]
+	\item \textbf{Partial scoring:} The main task allows partial (per object) scoring.
+	
 	\item \textbf{Keep going:} The robot should keep trying to determine the referred to object until they score or run out of time.
 
 	\item \textbf{Skipping groups:} The robot may say \emph{Pass} or \emph{I give up} to try with the next object.
@@ -69,6 +71,7 @@ The robot identifies (touching or naming) each object at which the operator is p
 	The average distance between the starting position and each group ranges between 50cm and 150cm.
 
 \end{enumerate}
+\enlargethispage{\baselineskip} % Remove if description fits on page again
 
 \subsection*{Referee instructions}
 

--- a/tasks/Receptionist.tex
+++ b/tasks/Receptionist.tex
@@ -30,6 +30,8 @@ Introduce and allocate two newcomers in a party.
 
 \subsection*{Additional rules and remarks}
 \begin{enumerate}[nosep]
+	\item \textbf{Partial scoring:} The main task allows partial (per guest) scoring.
+	
 	\item \textbf{Deus ex Machina:} Score reduction for requesting human assistance is applied per guest.
 
 	\item \textbf{Guests:} Each guest has assigned a predefined name and a favorite drink. At least one guest is female.

--- a/tasks/ServingDrinks.tex
+++ b/tasks/ServingDrinks.tex
@@ -38,6 +38,8 @@ Deliver a drink to all people without one.
 
 \subsection*{Additional rules and remarks}
 \begin{enumerate}
+	\item \textbf{Partial scoring:} The main task allows partial (per drink) scoring.
+	
 	\item \textbf{Partial scoring:} The main task allows partial scoring.
 	Robot score per correct delivered drink.
 

--- a/tasks/SticklerForRules.tex
+++ b/tasks/SticklerForRules.tex
@@ -22,6 +22,7 @@ Identify all party guests breaking the house rules and politely ask them to stop
 
 \subsection*{House Rules:}
 \begin{enumerate}[nosep]
+	\item \textbf{Partial scoring:} The main task allows partial (per offender) scoring.
 % \begin{enumerate}[nosep,label=\Roman.~]
 	\item \textit{No shoes inside the house.}\\
 	\textbf{Policy:} All guests have to take off their shoes at the entrance.\\

--- a/tasks/StoringGroceries.tex
+++ b/tasks/StoringGroceries.tex
@@ -24,6 +24,8 @@ Move objects 5 from a table into a shelf, grouping them by category or similarit
 % %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection*{Setup}
 \begin{enumerate}
+	\item \textbf{Partial scoring:} The main task allows partial (per object) scoring.
+	
 	\item \textbf{Location:} The testing area has a shelf and a table nearby.
 
 	\item \textbf{Shelf:} The shelf contains objects arranged in groups either by category or likeliness.

--- a/tasks/TakeOutGarbage.tex
+++ b/tasks/TakeOutGarbage.tex
@@ -27,6 +27,7 @@ The robot takes out the trash bags from the two bins in the apartment.
 
 \subsection*{Additional rules and remarks}
 \begin{enumerate}[nosep]
+	\item \textbf{Partial scoring:} The main task allows partial (per bag) scoring.
 	\item \textbf{Deus ex Machina:} Score reduction for requesting human assistance is applied per bag as follows:
 	\begin{itemize}[nosep]
 		\item Handing a bag over to the robot results in a score reduction of 200pts per bag.

--- a/tasks/WhereIsThis.tex
+++ b/tasks/WhereIsThis.tex
@@ -25,6 +25,7 @@ Give accurate directions and guide at least 3 people.
 
 \subsection*{Additional rules and remarks}
 \begin{enumerate}[nosep]
+	\item \textbf{Partial scoring:} The main task allows partial (per direction) scoring.
 	\item \textbf{Deus ex Machina:}
 	\begin{itemize}[nosep]
 		\item \textbf{Bypassing speech recognition:} Bypassing ASR causes a score reduction of 50pts per guest.


### PR DESCRIPTION
@awesomebytes pointed out in #664 that some tasks did not allow partial scoring for the main task. I added the remark for all the task where I think the intent of the task is to be scored partially.