### PR TITLE
Add GitHub templates and docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,28 @@
+---
+name: Bug
+about: Report a problem with the Rulebook.
+title: ''
+labels: Bug
+assignees: ''
+---
+
+## Describe the bug
+A clear and concise description of what the bug is.
+If it is a compile error, please provide a full traceback of the error that you received (if any), regardless of how long it is. 
+
+## To Reproduce
+Steps to reproduce the behavior
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected behavior
+A clear and concise description of what you expected to happen.
+
+## System (please complete the following information):
+ - OS: [e.g. OSX, Linux]
+ - LaTeX version: 
+
+## Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,37 @@
+---
+name: Question
+about: Ask about something you don't understand.
+title: 'Q: [3-5 words encapsulating your question]'
+labels: Question
+assignees: ''
+
+---
+
+
+### Before posting your question
+
+Before posting your question, please make sure you have:
+1. Searched within existing [issues](https://github.com/RoboCupAtHome/RuleBook/issues?q=is%3Aissue+label%3AQuestion) for related questions.
+2. Searched for your question in the [F.A.Q.](https://github.com/RoboCupAtHome/RuleBook/wiki/FAQ:-Frequently-Asked-Questions)
+
+## Quick guide
+
+1. Ask only **one question per issue**
+2. Make the **title short and descriptive**
+    1. Start with *Q:*
+    2. Use the acronym of the related test (if any)
+    3. Avoid obvious words like: *question, about, doubt, wrong, example*, etc.
+3. Make the body of the issue concise but explicative
+4. (If you are a contributor already) Add the label of the related test(s), or *General Rules* for questions affecting all of the rulebook
+5. Close the issue once your question has been answered
+
+===
+
+## Summary
+Summary of the question here (one concise paragraph).
+
+## Details
+Any additional details and examples relevant to your question.
+Please link to the branch/file/line-number or at least to the relevant section of the rules.
+Do not refer to date/build/page.
+Always double check your spelling and grammar :)

--- a/.github/ISSUE_TEMPLATE/suggestion.md
+++ b/.github/ISSUE_TEMPLATE/suggestion.md
@@ -1,0 +1,19 @@
+---
+name: Idea
+about: Suggest an idea for the rulebook.
+title: ''
+labels: Idea
+assignees: ''
+---
+
+## Is your idea/suggestion related to a problem? Please describe.
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+## Describe the solution you'd like
+A clear and concise description of what you want to happen.
+
+## Describe alternatives you've considered
+A clear and concise description of any alternative solutions you've considered.
+
+## Additional context
+Add any other context about the suggestion here.

--- a/.github/code_of_conduct.md
+++ b/.github/code_of_conduct.md
@@ -1,0 +1,25 @@
+## RoboCup Federation Code of Conduct
+ 
+Approved April 2019
+
+The RoboCup Federation (RCF) coordinates a variety of competitions, conferences, workshops, educational outreach activities, and online discussions pertaining to advancing the state of the art in AI and robotics research.
+
+RoboCup has a rich past record of fostering inclusion and respect for all participants and remains dedicated to providing a respectful and inclusive experience for everyone. Respectful behavior is always, and has always been, assumed and expected of community members in all interactions.
+
+Competition participants and attendees are expected to interact with others in a respectful and courteous manner, and to abide by standard academic practices of giving appropriate credit for other peoples' ideas.
+
+Abusive, racist, sexist, homophobic, intimidating, harassing, or threatening behavior towards any other event participant or directed at any organizer, student volunteer, sponsor, event staff, or spectators, will not be tolerated. RoboCup disapproves of offensive actions, aggressive acts, or comments that intimidate or disparage others. RoboCup will not tolerate any kind of harassment, including but not limited to:
+* Verbal attacks, accusations, bullying, or offensive comments Aggressive or intimidating behavior
+* Sustained disruption during presentations and other events
+* Unwelcome sexual attention
+* Inappropriate physical contact
+* Deliberate intimidation or stalking either in person or online Sexual and racist images or materials in public spaces
+* Ignoring, encouraging, or advocating any of the above behaviors
+
+RoboCup also disapproves of, and will not tolerate acts of plagiarism.
+
+All persons, organizations and entities that attend RoboCup events are subject to the standards of conduct set forth above. RoboCup expects all community members to formally endorse this code of conduct, and to actively prevent and discourage any undesired behaviors. Everyone should feel empowered to politely engage when themselves or others are disrespected, and to raise awareness and understanding of this code of conduct. RoboCup event participants asked to stop their unacceptable behavior are expected to comply immediately. Sponsors are also subject to this code of conduct in their participation in RoboCup events.
+
+All RoboCup agents and/or representatives are empowered to take all necessary action to prevent and/or stop any conduct that violates this code including but not limited to demanding that the violator be removed either temporarily or permanently from the current event and/or future events (without refund) or calling in local law enforcement officials to assist in the matter.
+
+To report any behavior that violates this code of conduct, please immediately report the conduct complained of to a RoboCup representative at the conference or event, or contact (by email or in person) the RoboCup president or any RoboCup trustee. The following email address may also be used: conduct@robocup.org. Complaints will be reviewed by a subcommittee of the board of trustees, and may be referred to law enforcement when warranted.

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,0 +1,25 @@
+Thanks for considering contributing! The league only exists with the support of the community.
+
+## How Can I Contribute?
+
+### Do you have an idea to improve the rules?
+
+Please open [a new GitHub issue](https://github.com/RoboCupAtHome/RuleBook/issues) describing your idea.
+
+### Did you write a fix for a bug?
+
+Contributions to the rulebook must be in the form of pull requests and meet the conventions and policies described in the [contribution guidelines](https://github.com/RoboCupAtHome/RuleBook/wiki/Guidelines:-Contributing). For guidelines about the workflow check [here](https://github.com/RoboCupAtHome/RuleBook/wiki/Guidelines:-Workflow).
+
+### I want to help maintain the league website
+
+We're always looking for volunteers to help in tasks such as organizing and categorizing publications, team videos, memories, scores, press, and writing examples and extended rule explanations. 
+Please contact the Organizing Committee.
+
+### Do you want to develop a utility for the competition?
+
+Great! The league has benefited from contributions like the [command generator](https://github.com/kyordhel/GPSRCmdGen) and [VizBox](https://github.com/RoboCupAtHome/vizbox). If you have a specific idea for a new tool for teams or for refereeing, please  [open a new GitHub issue](https://github.com/RoboCupAtHome/RuleBook/issues) describing your proposal.
+
+### Do you want to help run the competition?
+
+The RoboCup @Home Organizing Committee is always looking for volunteers to help run the event. Please contact the committee.
+

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -23,3 +23,31 @@ Great! The league has benefited from contributions like the [command generator](
 
 The RoboCup @Home Organizing Committee is always looking for volunteers to help run the event. Please contact the committee.
 
+
+## Contribution Naming Conventions
+
+### Files
+TeX files describing test files are named using a *Letter-case separated words* convention in which the first letter of each word is capital. When using acronyms, the next word can be separated with an underscore. All other file names are specified in lowercase (with the exception of acronyms), and separating words with underscores.
+
+The following practices must also be followed:
+- Spaces in filenames must be avoided.
+- The format for date designations is YYYYMMDD (to ensure chronological order over years).
+- File names should be as short as possible (max 25 characters + extension).
+- Special characters such as  ~ ! @ # $ % ^ & * ( ) ` ; < > ? , [ ] { } ' " and | should be avoided.
+- When using a sequential numbering system, three leading zeros are added for clarity.
+
+### Branches
+Branch names use always small caps (except by acronyms) with words separated with the underscore character.
+
+The name of a branch strongly depends on the introduced change type and the function of the change. Branch names must always be short and descriptive, avoiding sequences and special characters. The following branch types are set:
+- **```year/```** Used for tests mainly, and other changes targeting an specific year.
+  - ```2020/taking_the_bus```
+  - ```2025/IKEA_assembly```
+- **```feature/```** Used to introduce new features and general rules in the rulebook, as well as changes that affect many tests, or modify the scoring.
+  - ```feature/description_of_new_stuff```
+  - ```feature/eegpsr_example_scoresheet```
+- **```fix/```** Used to address or solve an specific issue
+  - ```fix/#185_remove_exact_numbers```
+  - ```fix/#500```
+
+**Important Remark:** Branches shall never be merged into ```master```, nor ```master``` shall merge into any branches. Pull Requests are mandatory for merging, and rebase for updating. Also, squash commits are not permitted.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+** Note: Your contribution is expected to meet the conventions and policies described in the [contribution guidelines](https://github.com/RoboCupAtHome/RuleBook/wiki/Guidelines:-Contributing) **
+
+## Description
+
+Closes issue #
+
+Changes proposed in this pull request:
+-
+-
+-
+
+## Other comments
+If this request is marked as a draft, please describe your plans or any specific feedback you would like


### PR DESCRIPTION
- Adds [templates for common types of issues and pull requests](https://help.github.com/en/articles/about-issue-and-pull-request-templates)
- Reformat some wiki content to make sense as a ["contributing" landing document](https://help.github.com/en/articles/setting-guidelines-for-repository-contributors)
- Adds a copy of the official [RoboCup Federation code of conduct](http://data.robocup.org.s3.amazonaws.com/data/upload/docs/RoboCup_Code_of_Conduct.pdf)

These templates and documents are presented throughout the contribution flow and should help nudge contributors in the right direction.