### PR TITLE
Add helper script to compile in Docker

### DIFF
--- a/latexdockercmd.sh
+++ b/latexdockercmd.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+IMAGE=blang/latex:ubuntu
+exec docker run --rm -i --user="$(id -u):$(id -g)" --net=none -v "$PWD":/data "$IMAGE" "$@"


### PR DESCRIPTION
Usage:

    ./latexdockercmd.sh pdflatex Rulebook.tex

Requires Docker to be installed- but not LaTeX.

## Description

I'm lazy and don't like installing things.
This allows me to edit the RuleBook faster.
I assume other people are lazy too.

## Other comments
This is just a helper script, it makes it really easy for people to contribute to the RuleBook. I have only tested it on Linux but in theory anything with Docker installed will work, no need to install LaTeX. LaTeX is large, so the first run will download LaTeX in a docker and run everything cleanly inside of the container.

The script mounts the present working directory with the correct user which is nice becuase it doesn't mess with git or local editors etc.