### PR TITLE
Make Take out the Garbage more challenging

### DIFF
--- a/scoresheets/TakeOutGarbage.tex
+++ b/scoresheets/TakeOutGarbage.tex
@@ -3,18 +3,19 @@ The maximum time for this test is 5 minutes.
 
 \begin{scorelist}
 	\scoreheading{Main Goal}
-	\scoreitem[2]{250}{Move a bag inside the designated zone}
-	\penaltyitem[2]{-200}{Receiving the bag via handover}
+	\scoreitem[2]{150}{Move a bag inside the designated zone}
+	\penaltyitem[2]{-75}{Receiving help removing bin lid}
+	\penaltyitem[2]{-75}{Receiving the bag via handover}
 	\penaltyitem[2]{-100}{Placing bag outside collection zone}
 	\penaltyitem[2]{-50}{Tipping a bin / tearing a bag}
+	\scoreitem[2]{100}{Move item into bin}
+	\penaltyitem[2]{-75}{Receiving item via handover}
 
 
 	\scoreheading{Bonus rewards}
-	\scoreitem[2]{100}{Opening the bin lid}
 	\scoreitem{300}{Carry both bags at once}
 
-	% No longer necessary, computes automatically
-	% \setTotalScore{1000}
+
 \end{scorelist}
 
 

--- a/tasks/TakeOutGarbage.tex
+++ b/tasks/TakeOutGarbage.tex
@@ -1,25 +1,26 @@
 \section{Take Out the Garbage [Housekeeper]}
 \label{test:take-out-the-garbage}
-All garbage bins in the apartment are emptied and the garbage has been moved to a specified collection zone.
+The robot picks up garbage from the floor and takes out the trash bags from the two bins in the apartment.
 
 % \subsection*{Focus}
 % This test focuses on object perception, manipulation, and planning.
 
 \subsection*{Main Goal}
-The robot takes out the trash bags from the two bins in the apartment.
+The area near the garbage bins is free of garbage, all garbage bins in the apartment are emptied and the garbage has been moved to a specified collection zone.
 
-\noindent\textbf{Reward:} 500pts (250pts per bag)
+
+\noindent\textbf{Reward:} 500pts (150pts per bag, 100pts per item)
 
 \subsection*{Bonus rewards}
 \begin{enumerate}[nosep]
-	\item Removing the lid of a bin. (100pts per bin)
 	\item Transporting both bags at once. (300pts)
 \end{enumerate}
 
 \subsection*{Setup}
 \begin{itemize}[nosep]
 	\item \textbf{Location:} This test takes place inside the arena.
-	\item \textbf{Bins:} There are two small trash bins in different rooms of the apartment. They are roughly cylindrical and open at the top. The space above the bin will be free of obstructions. The bin may be placed against a wall. Bin locations are part of the communicated arena setup.
+	\item \textbf{Bins:} There are two small trash bins in different rooms of the apartment. They are roughly cylindrical and open at the top, though they are covered with a lid by default. The space above the bin will be free of obstructions. The bin may be placed against a wall. Bin locations are part of the communicated arena setup.
+	\item \textbf{Objects:} Two unknown objects placed on the floor within view of the bins.
 	\item \textbf{Bags:} Each bin contains a tied garbage bag with some light contents. The color of the bag is different from the color of the bin.
 	\item \textbf{Collection Zones:} The collection zone is a designated area near the entrance.
 \end{itemize}
@@ -27,14 +28,14 @@ The robot takes out the trash bags from the two bins in the apartment.
 
 \subsection*{Additional rules and remarks}
 \begin{enumerate}[nosep]
-	\item \textbf{Deus ex Machina:} Score reduction for requesting human assistance is applied per bag as follows:
-	\begin{itemize}[nosep]
-		\item Handing a bag over to the robot results in a score reduction of 200pts per bag.
+	\item \textbf{Deus ex Machina:} The following reductions apply :
+	\begin{itemize}
+	    \item Removing the lid for the robot results in a score reduction of 75pts per lid.
+		\item Handing a bag to the robot results in a score reduction of 75pts per bag.
+		\item Handing an item to the robot results in a reduction of 75pts per item.
 	\end{itemize}
-
 	\item \textbf{Bag placement:} Placing a bag outside the collection zone results in a score reduction of 100pts per bag.
 	\item \textbf{Manipulation:}  Tipping over a bin or tearing the bag results in a score reduction of 50pts per bag.
-	\item \textbf{Closed bins:} The team leader may request to place a lid on one or both of the bins to score the bonus points.
 
 \end{enumerate}
 


### PR DESCRIPTION
## Description

Makes _Take out the Garbage_ harder

Changes proposed in this pull request:
- Require lid removal
- Add nearby floor garbage which must be placed in the bin

## Other comments
From discussion in #685, there is enthusiasm about both _Clean up_ and _Take out the Garbage_, but we will only keep one. There has also been some agreement that _Garbage_ will need to be harder. One path could be to add an element of _Clean up_ to _Garbage_. 

Not sure about how the score balancing would look, I just put down something roughly feasible. Bonuses would have to be reworked too.