### PR TITLE
Fix docker compiler script & documentation

### DIFF
--- a/latexdockercmd.sh
+++ b/latexdockercmd.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 
-if [ $# -ne 2 ]; then
+if [ $# -lt 2 ]; then
   echo "usage: "
   echo "  "$0" [command] [filename]"
   echo "  Command uses https://github.com/blang/latex-docker see README for full details\n"
   echo "  quick pass:"
-  echo "    "$0" pdflatex Rulebook.pdf"
+  echo "    "$0" pdflatex Rulebook.tex"
   echo "  full build:"
-  echo "    "$0" /bin/sh -c \"pdflatex Rulebook.tex && makeindex Rulebook.tex && makeindex Rulebook.tex && pdflatex Rulebook.tex && pdflatex Rulebook.tex"
+  echo "    "$0" /bin/sh -c \"pdflatex Rulebook.tex && makeindex Rulebook.tex && makeindex Rulebook.tex && pdflatex Rulebook.tex && pdflatex Rulebook.tex\""
   exit 1
 fi
 


### PR DESCRIPTION
- fix error that script didn't accept more than 2 arguments
- fix missing quote in full compile example
- fix typo pdf->tex in quick compile example
