### PR TITLE
Storing Groceries: Reduce points for opening shelf door

### DIFF
--- a/scoresheets/StoringGroceries.tex
+++ b/scoresheets/StoringGroceries.tex
@@ -8,7 +8,7 @@ The maximum time for this test is 5 minutes.
 	\penaltyitem[5]{-100}{Receiving human help (move object)}
 
 	\scoreheading{Bonus rewards}
-	\scoreitem{300}{Opening the shelf door without human help}
+	\scoreitem{100}{Opening the shelf door without human help}
 	\scoreitem{100}{Moving a \emph{tiny} object}
 	\scoreitem{100}{Moving a \emph{heavy} object}
 

--- a/tasks/StoringGroceries.tex
+++ b/tasks/StoringGroceries.tex
@@ -1,18 +1,18 @@
 \section{Storing Groceries [Housekeeper]}
 \label{test:storing-groceries}
-The robot stores groceries into a pantry shelf while paying attention to sorting objects in their appropriate place, i.e.~storing an apple next to other fruits.
+The robot stores groceries into a pantry shelf while adhering to how objects are arranged in it, i.e. storing an apple next to other fruits.
 
 % \subsection*{Focus}
 % This test focuses on the detection and recognition of objects and their features, as well as object manipulation.
 
 \subsection*{Main Goal}
-Move objects 5 from a table into a shelf, grouping them by category or similarity.
+Move 5 objects from a table into a shelf, grouping them by category or similarity.
 
 \noindent\textbf{Reward:} 500pts (100pts per object).\\
 
 \subsection*{Bonus rewards}
 \begin{enumerate}[nosep]
-	\item Opening the shelf door (300pts)
+	\item Opening the shelf door (100pts)
 	\item Moving a \emph{tiny} object (100pts)
 	\item Moving a \emph{heavy} object (100pts)
 \end{enumerate}
@@ -49,7 +49,7 @@ Move objects 5 from a table into a shelf, grouping them by category or similarit
 		\item Telling or pointing out to the robot where to place an object results in a score reduction of 30pts.
 	\end{itemize}
 
-	\item \textbf{Table} The table's rough location will be announced beforehand, having its position either left, right, or behind the robot.
+	\item \textbf{Table} The table's rough location will be announced beforehand and will be close to the robot's starting position.
 \end{enumerate}
 
 \newpage

--- a/tasks/StoringGroceries.tex
+++ b/tasks/StoringGroceries.tex
@@ -1,6 +1,6 @@
 \section{Storing Groceries [Housekeeper]}
 \label{test:storing-groceries}
-The robot stores groceries into a pantry shelf while adhering to how objects are arranged in it, i.e. storing an apple next to other fruits.
+The robot stores groceries into a pantry shelf while adhering to how objects are arranged in it, i.e.~storing an apple next to other fruits.
 
 % \subsection*{Focus}
 % This test focuses on the detection and recognition of objects and their features, as well as object manipulation.
@@ -13,8 +13,8 @@ Move 5 objects from a table into a shelf, grouping them by category or similarit
 \subsection*{Bonus rewards}
 \begin{enumerate}[nosep]
 	\item Opening the shelf door (100pts)
-	\item Moving a \emph{tiny} object (100pts)
-	\item Moving a \emph{heavy} object (100pts)
+	\item Moving a \emph{tiny} object (200pts)
+	\item Moving a \emph{heavy} object (200pts)
 \end{enumerate}
 
 % %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
This PR contains minor spelling and grammar changes.
The main change is reducing bonus points for opening the door from 300 to 100.
In the TC meeting we considered making the door opening mandatory, but personally I think the league is not quite there yet. Afaik no OPL or SSPL robots opened the door (correct me here since I was not in Sydney). 

Something else I considered: Only award points for door opening when 2 or more objects are correctly moved to encourage teams to work on the main goal. I opted not to go for this since it adds an exception to a general rule which should be avoided as much as possible imo. But I could be convinced otherwise.