### PR TITLE
Add remark about Standard Objects in General Rules

### DIFF
--- a/general_rules/Scenario.tex
+++ b/general_rules/Scenario.tex
@@ -156,6 +156,10 @@ There are two types of objects:
 	\item \textbf{\iterm{Unknown objects}:} Any other object that is not known beforehand but can be grasped or handled.
 \end{enumerate}
 
+\paragraph*{Remark:} Most (known) objects used in the competition are chosen from the YCB dataset (see {\small\url{http://www.ycbbenchmarks.com/object-set/}}).
+These objects are considered standard, and can be acquired and trained in advance.
+Additional information about which \iterm{standard objects} were chosen, their official names, categories, and how to acquire them, can be found in the RoboCup@Home Official Website {\small\url{https://athome.robocup.org/standard-objects}} no later than 6 months prior to the \YEAR{} competition.
+
 \subsection{List of Predefined Objects}
 \label{rule:scenario_objects_list}
 The minimal configuration consists of:


### PR DESCRIPTION
## Description
Adds a remark stating that most objects (doesn't specify how many adding some flexibility) used in the competition will be selected from the YCB dataset, hence will be Standard. To keep the rulebook concise and short refers the reader to the official website. It also grants teams half a year to conduct set acquisition and training.

Closes issue #703 #673 

## Changes
Adds the following text at the end of **§3.3.5 Objects**
> **Remark:** Most (known) objects used in the competition are chosen from the YCB dataset (see [`http://www.ycbbenchmarks.com/object-set/`](http://www.ycbbenchmarks.com/object-set/)). These objects are considered standard, and can be acquired and trained in advance. Additional information about which *standard objects* were chosen, their official names, categories, and how to acquire them, can be found in the RoboCup@Home Official Website [`https://athome.robocup.org/standard-objects`](https://athome.robocup.org/standard-objects) no later than 6 months prior to the 2019 competition.

## Remarks
1. Unlike #703 there are no changes to any rule or object categorization, just an addendum. Further discussion on re-categorization can be conducted afterwards without delaying any further the official announcement of the partial object standardization.
2. The page https://athome.robocup.org/standard-objects is not live yet due to a server migration.