### PR TITLE
Add initial GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,97 @@
+name: CI
+
+on: [push]
+
+jobs:
+  lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: LaTeX linter (chktex)
+        uses: j2kun/chktex-action@v1.0.0
+        # Provide this output for context, but don't fail builds
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-rulebook:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: LaTeX compilation
+      uses: dante-ev/latex-action@v0.2.0
+      with:
+        root_file: Rulebook.tex
+    - name: Upload build result
+      uses: actions/upload-artifact@v1
+      with:
+        name: rulebook
+        path: Rulebook.pdf
+    - name: Commit output to GitHub Pages
+      if: github.ref == 'refs/heads/master'
+      run: |
+        # configure git
+        cd "$GITHUB_WORKSPACE"
+        git config --global user.name "Continuous Deployment"
+        git config --global user.email "git@robocupathome.org"
+        git checkout origin/gh-pages
+        mkdir -p rulebook
+        FILENAME=${GITHUB_REF/refs\/heads\//}
+        # Strip out any extra slashes in the rest
+        FILENAME=${FILENAME//\//\_}.pdf
+        cp -f Rulebook.pdf rulebook/$FILENAME
+        git add rulebook/$FILENAME
+        # Remove untracked files
+        git clean -f
+        # If the built PDF is actually different, commit it
+        git diff-index --quiet HEAD || git commit -m "[github actions] deploy"
+    - name: Push to GitHub Pages
+      if: github.ref == 'refs/heads/master'
+      uses: ad-m/github-push-action@v0.5.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: gh-pages
+
+  build-scoresheets:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: LaTeX compilation
+      uses: dante-ev/latex-action@v0.2.0
+      with:
+        root_file: score_sheets.tex
+    - name: Upload build result
+      uses: actions/upload-artifact@v1
+      with:
+        name: score_sheets
+        path: score_sheets.pdf
+    - name: Commit output to GitHub Pages
+      if: github.ref == 'refs/heads/master'
+      run: |
+        # configure git
+        cd "$GITHUB_WORKSPACE"
+        git config --global user.name "Continuous Deployment"
+        git config --global user.email "git@robocupathome.org"
+        git checkout origin/gh-pages
+        mkdir -p score_sheets
+        FILENAME=${GITHUB_REF/refs\/heads\//}
+        # Strip out any extra slashes in the rest
+        FILENAME=${FILENAME//\//\_}.pdf
+        cp -f score_sheets.pdf score_sheets/$FILENAME
+        git add score_sheets/$FILENAME
+        # Remove untracked files
+        git clean -f
+        # If the built PDF is actually different, commit it
+        git diff-index --quiet HEAD || git commit -m "[github actions] deploy"
+    - name: Push to GitHub Pages
+      if: github.ref == 'refs/heads/master'
+      uses: ad-m/github-push-action@v0.5.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: gh-pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,30 +31,7 @@ jobs:
       with:
         name: rulebook
         path: Rulebook.pdf
-    - name: Commit output to GitHub Pages
-      if: github.ref == 'refs/heads/master'
-      run: |
-        # configure git
-        cd "$GITHUB_WORKSPACE"
-        git config --global user.name "Continuous Deployment"
-        git config --global user.email "git@robocupathome.org"
-        git checkout origin/gh-pages
-        mkdir -p rulebook
-        FILENAME=${GITHUB_REF/refs\/heads\//}
-        # Strip out any extra slashes in the rest
-        FILENAME=${FILENAME//\//\_}.pdf
-        cp -f Rulebook.pdf rulebook/$FILENAME
-        git add rulebook/$FILENAME
-        # Remove untracked files
-        git clean -f
-        # If the built PDF is actually different, commit it
-        git diff-index --quiet HEAD || git commit -m "[github actions] deploy"
-    - name: Push to GitHub Pages
-      if: github.ref == 'refs/heads/master'
-      uses: ad-m/github-push-action@v0.5.0
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: gh-pages
+
 
   build-scoresheets:
 
@@ -71,22 +48,41 @@ jobs:
       with:
         name: score_sheets
         path: score_sheets.pdf
+
+  deploy-pdfs:
+
+    runs-on: ubuntu-latest
+    needs: [build-rulebook, build-scoresheets]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Download rulebook
+      uses: actions/download-artifact@v1
+      with:
+        name: rulebook
+        path: ${{ runner.temp }}/rulebook
+    - name: Download score sheets
+      uses: actions/download-artifact@v1
+      with:
+        name: score_sheets
+        path: ${{ runner.temp }}/score_sheets
     - name: Commit output to GitHub Pages
       if: github.ref == 'refs/heads/master'
+      env:
+        ARTIFACTS_PATH: ${{ runner.temp }}
       run: |
         # configure git
         cd "$GITHUB_WORKSPACE"
         git config --global user.name "Continuous Deployment"
         git config --global user.email "git@robocupathome.org"
         git checkout origin/gh-pages
+        mkdir -p rulebook
         mkdir -p score_sheets
         FILENAME=${GITHUB_REF/refs\/heads\//}
         # Strip out any extra slashes in the rest
         FILENAME=${FILENAME//\//\_}.pdf
-        cp -f score_sheets.pdf score_sheets/$FILENAME
-        git add score_sheets/$FILENAME
-        # Remove untracked files
-        git clean -f
+        mv $ARTIFACTS_PATH/rulebook/Rulebook.pdf rulebook/$FILENAME
+        mv $ARTIFACTS_PATH/score_sheets/score_sheets.pdf score_sheets/$FILENAME
+        git add rulebook/$FILENAME score_sheets/$FILENAME
         # If the built PDF is actually different, commit it
         git diff-index --quiet HEAD || git commit -m "[github actions] deploy"
     - name: Push to GitHub Pages

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 RuleBook for RoboCup @Home 2019
 ===============================
 
+![](https://github.com/RoboCupAtHome/RuleBook/workflows/CI/badge.svg?branch=master)
+
 The 2019 rulebook state is **FINAL**.
 
 Only spelling corrections and minor clarificatios may be merged from now on, as well as buffs to the scoresheets to enhance scoring.
 All work for the Rulebook of 2020 shall be pushed into to 2020/Rulebook.
 
-[On-the-fly compiled LaTeX version](http://latex.aslushnikov.com/compile?git=git://github.com/RoboCupAtHome/RuleBook.git&target=Rulebook.tex)
+[On-the-fly compiled LaTeX version](https://robocupathome.github.io/RuleBook/rulebook/master.pdf)
 
 [Released PDF version](https://athome.robocup.org/wp-content/uploads/2019_rulebook.pdf)
 

--- a/score_sheets.tex
+++ b/score_sheets.tex
@@ -150,15 +150,11 @@
 \input{scoresheets/HandMeThat.tex}
 \end{scoresheet}
 
-% \renewcommand{\currentTest}{Restaurant}
-% \begin{scoresheet}
-% \input{scoresheets/Restaurant.tex}
-% \end{scoresheet}
-
-\renewcommand{\currentTest}{Where is this}
+\renewcommand{\currentTest}{Restaurant}
 \begin{scoresheet}
-\input{scoresheets/WhereIsThis}
+\input{scoresheets/Restaurant.tex}
 \end{scoresheet}
+
 
 % %%% FINALS   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
## Description

Adopts GitHub Actions to perform basic continuous integration. This addresses two concerns: getting a publicly viewable development copy available again, and making sure contributions compile.

Closes issue #693 

Changes proposed in this pull request:
- Builds rulebook and scoresheets on every commit
- Stores built PDFs alongside logs (short term storage)
- On master only, push the built PDFs up to GitHub pages
- Drop latexonline and point to the GitHub PDF
- Also run a linter for informational purposes only