### PR TITLE
Use personal access token for deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,5 +89,5 @@ jobs:
       if: github.ref == 'refs/heads/master'
       uses: ad-m/github-push-action@v0.5.0
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.DEPLOY_PAT }}
         branch: gh-pages


### PR DESCRIPTION
## Description

Turns out, the provided GITHUB_TOKEN doesn't trigger GitHub Pages builds (even though it can push successfully). [It's not clear](https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869) if this is a bug or a feature intended to prevent recursive triggers.

Changes proposed in this pull request:
- Use a personal access token when pushing to `gh-pages`