### PR TITLE
Run CI builds through the makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,8 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: LaTeX compilation
-      uses: dante-ev/latex-action@v0.2.0
-      with:
-        root_file: Rulebook.tex
+      run:
+       sudo ./latexdockercmd.sh /bin/sh -c "TERM=xterm make dorulebookonly"
     - name: Upload build result
       uses: actions/upload-artifact@v1
       with:

--- a/README.md
+++ b/README.md
@@ -1,22 +1,20 @@
-RuleBook for RoboCup @Home 2019
+RuleBook for RoboCup @Home 2019 [![](https://github.com/RoboCupAtHome/RuleBook/workflows/CI/badge.svg?branch=master)](https://github.com/RoboCupAtHome/RuleBook/actions?query=workflow%3ACI)
 ===============================
-
-![](https://github.com/RoboCupAtHome/RuleBook/workflows/CI/badge.svg?branch=master)
 
 The 2019 rulebook state is **FINAL**.
 
 Only spelling corrections and minor clarificatios may be merged from now on, as well as buffs to the scoresheets to enhance scoring.
 All work for the Rulebook of 2020 shall be pushed into to 2020/Rulebook.
 
-[On-the-fly compiled LaTeX version](https://robocupathome.github.io/RuleBook/rulebook/master.pdf)
+[Current PDF (master)](https://robocupathome.github.io/RuleBook/rulebook/master.pdf)
 
-[Released PDF version](https://athome.robocup.org/wp-content/uploads/2019_rulebook.pdf)
+[Released PDF version (2019)](https://athome.robocup.org/wp-content/uploads/2019_rulebook.pdf)
 
 RoboCup@Home teams and team members are welcome to post GitHub issues for clarifications, questions etc.
 
 Improvements are also welcome in the form of pull requests (see [guidelines](https://github.com/RoboCupAtHome/RuleBook/wiki/Guidelines)).
 
-[Score sheets](http://latex.aslushnikov.com/compile?git=git://github.com/RoboCupAtHome/RuleBook.git&target=score_sheets.tex)
+[Score sheets (master)](https://robocupathome.github.io/RuleBook/score_sheets/master.pdf)
 
 ### FAQ
 See the Frequently Asked Questions [here](https://github.com/RoboCupAtHome/RuleBook/wiki/FAQ:-Frequently-Asked-Questions).


### PR DESCRIPTION
Changes proposed in this pull request:
- run CI through the makefile, using the existing docker-based helper script tracked in the repo. This ensures that the date stamp and the index get built properly
- update readme PDF, CI links
- add `pull_request` event as trigger so build checks happen on PRs from forks