### PR TITLE
2023 serve breakfast

### DIFF
--- a/scoresheets/ServeBreakfast.tex
+++ b/scoresheets/ServeBreakfast.tex
@@ -9,6 +9,7 @@ The maximum time for this test is 5 minutes.
 	\scoreheading{Bonus Rewards}
 	\scoreitem{300}{Pouring milk into the bowl}
 	\scoreitem{100}{Placing a spoon next to the bowl}
+	\scoreitem{100}{Placing a the breakfast in front of a chair}
 
 	\scoreheading{Regular Penalties}
 	\penaltyitem[4]{30}{Throwing or dropping an object on the table}

--- a/scoresheets/ServeBreakfast.tex
+++ b/scoresheets/ServeBreakfast.tex
@@ -16,6 +16,7 @@ The maximum time for this test is 5 minutes.
 	\penaltyitem{150}{Spilling milk while pouring}
 
 	\scoreheading{Deus Ex Machina Penalties}
+	\penaltyitem{100}{Remove chairs from the table}
 	\penaltyitem[4]{25}{Pointing at an object}
 	\penaltyitem[4]{50}{Handing an object over to the robot}
 	\penaltyitem[4]{75}{A human placing an object on the table}

--- a/tasks/ServeBreakfast.tex
+++ b/tasks/ServeBreakfast.tex
@@ -26,8 +26,8 @@ The robot has to set a table for breakfast for one person and prepare cereal for
 			\end{itemize}
 	\item \textbf{Furniture:}
 		\begin{itemize}
-			\item \textbf{Table:} The robot serves breakfast on any table or flat surface in the kitchen (the team is free to choose this location).
-			\item \textbf{Chairs:} Chairs may be placed around the kitchen table and won't be removed.
+			\item \textbf{Table:} The robot serves breakfast on the dinner table.
+			\item \textbf{Chairs:} Chairs may be placed around the kitchen table and may be removed upon request by the team.
 			\item \textbf{Doors:} The robot does not need to open any doors for finding the breakfast items.
 		\end{itemize}
 	\item \textbf{Objects:}
@@ -38,7 +38,7 @@ The robot has to set a table for breakfast for one person and prepare cereal for
 
 \subsection*{Procedure}
 \begin{enumerate}[nosep]
-	\item \textbf{Table selection:} Half an hour before the test starts, the team informs the referees about the surface that will be used as a table.
+	\item \textbf{Before the test:} The team informs the referees if they want the chairs around the table to be removed.
 	\item \textbf{Test start:} The team moves their robot to the kitchen and starts the task.
 	\item \textbf{Serving breakfast:} To serve breakfast, the robot has to place breakfast items on a table (bowl, spoon, cereal box, and milk carton).
 	\item \textbf{Pouring cereal:} After placing the breakfast items on the table, the robot should pour cereal into the bowl.

--- a/tasks/ServeBreakfast.tex
+++ b/tasks/ServeBreakfast.tex
@@ -46,6 +46,7 @@ The robot has to set a table for breakfast for one person and prepare cereal for
 		\begin{itemize}
 			\item \textbf{Pouring milk:} After pouring cereal, the robot pours milk into the bowl in order to fully prepare the breakfast.
 			\item \textbf{Placing the spoon next to the bowl:} In principle, the spoon can be placed anywhere on the table, but placing it next to the bowl is desired so that it is easily reachable by a person.
+			\item \textbf{Placing the breakfast in front of a chair:} In principle, the breakfast can be placed anywhere on the table, but placing it in front of a chair is desired so that it is easily reachable by a person.
 		\end{itemize}
 \end{enumerate}
 

--- a/tasks/ServeBreakfast.tex
+++ b/tasks/ServeBreakfast.tex
@@ -17,7 +17,7 @@ The robot has to set a table for breakfast for one person and prepare cereal for
 \begin{itemize}[nosep]
 	\item \textbf{Locations:}
 		\begin{itemize}
-			\item \textbf{Start location:} Before the test, the robot waits outside the \Arena{} and navigates to the kitchen when the door is open.
+			\item \textbf{Start location:} The robot starts in the kitchen.
 			\item \textbf{Test location:} The test itself takes place in the kitchen.
 		\end{itemize}
 		\item \textbf{People:}
@@ -39,7 +39,7 @@ The robot has to set a table for breakfast for one person and prepare cereal for
 \subsection*{Procedure}
 \begin{enumerate}[nosep]
 	\item \textbf{Table selection:} Half an hour before the test starts, the team informs the referees about the surface that will be used as a table.
-	\item \textbf{Test start:} The robot moves to the kitchen when the arena door is open.
+	\item \textbf{Test start:} The team moves their robot to the kitchen and starts the task.
 	\item \textbf{Serving breakfast:} To serve breakfast, the robot has to place breakfast items on a table (bowl, spoon, cereal box, and milk carton).
 	\item \textbf{Pouring cereal:} After placing the breakfast items on the table, the robot should pour cereal into the bowl.
 	\item \textbf{Optional goals:}


### PR DESCRIPTION
** Note: Your contribution is expected to meet the conventions and policies described in the [contribution guidelines](https://github.com/RoboCupAtHome/RuleBook/wiki/Guidelines:-Contributing) **

## Description

Make minor changes to the serve breakfast challenge.

Changes proposed in this pull request:
- Start challenge in the kitchen: save time and reduce failed tests due to probems at the door. 
- Make use of the dinner table mandatory: other flat surfaces in the kitchen don't make sense for serving breakfast and dont make it easier.
- Allow teams to request chairs to be removed for a deus ex machina penalty: Allow teams to choose their own level of dificulty while indicating that the solution with chairs is the prefered one.
-  Reward placing the breakfast in front of a chair like placing the spoon next to the bowl: placing the spoon is rather trivial. Much more realistic is to require the breakfast to be served in front of seat rather than anywhere on the table.

## Other comments
Topics still under consideration
- defining spilling: There should be a distinction between minor spilling where the robot spills a few drops/crums (like a normal human might do) and major spilling where the robot makes a big mess. 
- Specify moving the dinner table slighty before the challenge in referee instructions: general rules already state that furniture may be moved between tests but I think it would be good to put a reminder here. 
- Normalise points: make sure the points rewarded represent the challenge compared to other challenges.