### PR TITLE
change finals theme

### DIFF
--- a/tests/Finals.tex
+++ b/tests/Finals.tex
@@ -16,8 +16,8 @@ The \iterm{Finals} are a demonstration of achieving an objective that is pre-sel
 The objectives for each league for this year are:
 
 \begin{itemize}
-    \item \emph{OPL/DSPL}: The robot helps a person that has had a small accident in their home.
-    \item \emph{SSPL}: The robot monitors a person while they are going about their day and reacts appropriately if it notices any unusual events.
+    \item \emph{OPL/DSPL}: The robot helps a person in preparing dinner.
+    \item \emph{SSPL}: The robot monitors a person while they are preparing dinner and guides them through a recipe.
 \end{itemize}
 
 

--- a/tests/Finals.tex
+++ b/tests/Finals.tex
@@ -17,7 +17,7 @@ The objectives for each league for this year are:
 
 \begin{itemize}
     \item \emph{OPL/DSPL}: The robot helps a person in preparing dinner.
-    \item \emph{SSPL}: The robot monitors a person while they are preparing dinner and guides them through a recipe.
+    \item \emph{SSPL}: The robot helps a person in preparing dinner.
 \end{itemize}
 
 


### PR DESCRIPTION
** Note: Your contribution is expected to meet the conventions and policies described in the [contribution guidelines](https://github.com/RoboCupAtHome/RuleBook/wiki/Guidelines:-Contributing) **

## Description

Updates the theme for the finals for 2023

Changes proposed in this pull request:
- Theme for the final is to assist in cooking. The description should be broad enough that teams can give their own take on how they make the robot do this. 

## Other comments
One thing I am unsure of is the phrasing of the SSPL finals task. I think this may be too strict a definition. There are more than one ways in which a robot can help in preparing or even during the meal.