### PR TITLE
Broken references removed

### DIFF
--- a/general_rules/Organization.tex
+++ b/general_rules/Organization.tex
@@ -80,7 +80,7 @@ In case of having no considerable score deviation between a team advancing to th
 
 	\cell{Block 1\\\footnotesize(9:00--11:00)}
 		& \cell{Carry my Luggage}
-		& \cell{Take out the Garbage}
+		& \cell{Serve Breakfast}
 		& \cell{Restaurant}
 		& \cellcolor{white}
 		\\\hhline{~----}
@@ -95,7 +95,7 @@ In case of having no considerable score deviation between a team advancing to th
 	\cell{Block 2\\\footnotesize(13:00--15:00)}
 		& \cell{Receptionist}
 		& \cell{GPSR}
-		& \cell{TBD}
+		& \cell{Stickler for the Rules}
 		& \cellcolor{white}
 		\\\hhline{~---}
 		

--- a/general_rules/Procedure.tex
+++ b/general_rules/Procedure.tex
@@ -18,7 +18,7 @@
 	% \item \textbf{Open Demonstrations:} During the \iterm{Open Challenge} \iterm{Demo Challenge}, and the \iaterm{final demonstration}{Finals}, the number of team members inside the arena is not limited.
 	%\item \textbf{Open Demonstrations:} During the \iterm{Open Challenge}, and the \iaterm{final demonstration}{Finals}, the number of team members inside the arena is not limited.
 	\item \textbf{\FINAL:} During the \FINAL, the number of team members inside the \Arena{} is not limited.
-	\item \textbf{Moderation:} During a regular test, one team member \emph{must} be available to host and comment the test (see~\refsec{rule:moderator}).
+	%\item \textbf{Moderation:} During a regular test, one team member \emph{must} be available to host and comment the test (see~\refsec{rule:moderator}).
 \end{enumerate}
 
 \subsection{Fair play}

--- a/general_rules/Procedure.tex
+++ b/general_rules/Procedure.tex
@@ -18,7 +18,6 @@
 	% \item \textbf{Open Demonstrations:} During the \iterm{Open Challenge} \iterm{Demo Challenge}, and the \iaterm{final demonstration}{Finals}, the number of team members inside the arena is not limited.
 	%\item \textbf{Open Demonstrations:} During the \iterm{Open Challenge}, and the \iaterm{final demonstration}{Finals}, the number of team members inside the arena is not limited.
 	\item \textbf{\FINAL:} During the \FINAL, the number of team members inside the \Arena{} is not limited.
-	%\item \textbf{Moderation:} During a regular test, one team member \emph{must} be available to host and comment the test (see~\refsec{rule:moderator}).
 \end{enumerate}
 
 \subsection{Fair play}

--- a/setup/macros_score_sheets.tex
+++ b/setup/macros_score_sheets.tex
@@ -556,11 +556,11 @@
 	\scoreheading{Special Penalties \& Bonuses}
 
 	% not showing up penalty %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-	\penaltyitem{\notattendingpenalty}{Not attending \ifShortScoresheet{(see sec.~\ref{sec:rules:missingslot})}{}}
+	\penaltyitem{\notattendingpenalty}{Not attending \ifShortScoresheet{(see sec.~\ref{rule:not_attending})}{}}
 
 	% require signal for door opening %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	\ifthenelse{ \equal{\scorelistStartButton}{true} }{
-	  \penaltyitem{\scorelistStartButtonPenalty}{Using alternative start signal \ifShortScoresheet{(see sec.~\ref{sec:rules:startsignal})}{}}
+	  \penaltyitem{\scorelistStartButtonPenalty}{Using alternative start signal \ifShortScoresheet{(see sec.~\ref{rule:start_signal})}{}}
 	}{}
 
 	% data recording bonus %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
On file general_rules/Procedure the reference to Moderation in 3.7.2 was removed to be consistent with the removal of this section in a past review

File setup/macros_score_sheets.tex edited with correct references to Not attending and Alternative start signal references.

Table 3.1 updated to reference current tests (i.e. removed Take out the garbage and added Clean the Table and Stickler for the Rules)