### PR TITLE
Score update clean the table

### DIFF
--- a/scoresheets/CleanTable.tex
+++ b/scoresheets/CleanTable.tex
@@ -2,18 +2,17 @@ The maximum time for this test is 10 minutes.
 
 \begin{scorelist}
 	\scoreheading{Main Goal}
-	\scoreitem[5]{60}{Picking tableware and cutlery for transportation to the dishwasher}
-	\scoreitem[5]{180}{Placing the tableware and cutlery inside the dishwasher}
+	\scoreitem[5]{240}{Placing the tableware and cutlery inside the dishwasher}
 
 	\scoreheading{Bonus Rewards}
 	\scoreitem{200}{Opening the dishwasher door}
 	\scoreitem{100}{Pulling out the dishwasher rack}
-	\scoreitem[5]{40}{Placing an item correctly in the dishwasher}
-	\scoreitem{300}{Placing the dishwasher tab inside the dishwasher}
+	\scoreitem{200}{Placing all items correctly in the dishwasher}
+	\scoreitem{300}{Taking and placing the dishwasher tab inside the dishwasher}
 
 	\scoreheading{Deus Ex Machina Penalties}
-	\penaltyitem[5]{25}{Pointing at an object or telling the robot where an object is}
-	\penaltyitem[5]{60}{Handing an object over to the robot}
+	\penaltyitem[5]{100}{Pointing at an object or telling the robot where an object is}
+	\penaltyitem[5]{140}{Handing an object over to the robot}
 
 	%\setTotalScore{1000}
 \end{scorelist}


### PR DESCRIPTION
**Note: created this PR based on suggestions by @ARTenshi Luis Contreras**

## Description

Clean the table as described now seems too easy for a stage 2 task. Basically, the robot can request to be handed all objects and place them in a random deposit in the dishwasher and still score high; furthermore, by placing all objects in the same hardcoded rack, by definition, some of them will get the bonus points for the correct location. Finally, this applies to the dishwasher tab if it can be handed, as well. This is more a "Put the objects in the robot hand and deposit them in any rack" task. This is not suitable for a Stage II test.

Changes proposed in this pull request:
- Make picking up the dishwasher tab mandatory for the bonus points
- remove partial scoring for picking up an object
- award bonus points for correct placement only if all are correctly placed, to avoid it happening by coincidence
- increase deus ex machina penalty
