### PR TITLE
Updated Deus ex Machina and Setup

### DIFF
--- a/Setup.tex
+++ b/Setup.tex
@@ -1,6 +1,8 @@
 \chapter{Setup and Preparation}
 \label{chap:setup_and_preparation}
-Prior to the RoboCup@Home competition, all arriving teams will have an opportunity to set up their robots and prepare for the competition in a \iterm{Setup \& Preparation} phase. This phase is scheduled to start on the first day of the competition, namely when the venue opens and the teams arrive. During the \SetupDays, teams can assemble and test their robots. On the last setup day, a \WelcomeReception{} will be held. To foster the knowledge exchange between teams a conference-like \PS{} takes place during the reception. Additionally, all teams have to get their robots inspected by members of the TC to be allowed to participate in the competition.
+Prior to the RoboCup@Home competition, all arriving teams will have an opportunity to set up their robots and prepare for the competition in a \iterm{Setup \& Preparation} phase. This phase is scheduled to start on the first day of the competition, namely when the venue opens and the teams arrive. During the \SetupDays, teams can assemble and test their robots.
+%On the last setup day, a \WelcomeReception{} will be held. To foster the knowledge exchange between teams a conference-like \PS{} takes place during the reception.
+Additionally, all teams have to get their robots inspected by members of the TC to be allowed to participate in the competition.
 
 \paragraph{Regular tests are not conducted during the setup \& preparation phase.} The competition starts with \SONE{} (see~\refsec{chap:stage_I}).
 
@@ -42,26 +44,34 @@ Depending on the schedule, the \iterm{Setup \& Preparation} phase lasts for one 
 	\item \textbf{Objects:} The delegation of EC, TC, OC and local organizers will buy the objects (see~\refsec{rule:scenario_objects}). Note, however, that the objects may not be available at all times and not from the beginning of the \iterm{Setup \& Preparation}.
 \end{enumerate}
 
-\section{Welcome Reception}
-\label{sec:welcome_reception}
-Since Eindhoven 2013, RoboCup@Home holds an own \WelcomeReception{} in addition to the official opening ceremony. During the \WelcomeReception, a \PS{} is held in which teams present their research focus and latest results (see~\refsec{sec:poster_teaser_session}).
-\begin{enumerate}
-	\item \textbf{Time:} The \WelcomeReception{} is held in the evening of the last setup day.
-	\item \textbf{Place:} The \WelcomeReception{} takes place in the @Home \Arena{} and/or in the \AtHome{} team area.
-	\item \textbf{Snacks \& drinks:} During the \WelcomeReception{}, snacks and beverages (beers, sodas, etc.) are served.
-	\item \textbf{Organization:} It is the responsibility of the OC and the local organizers to organize the \WelcomeReception{} and \PS{}, including:
-		\begin{enumerate}
-			\item organizing poster stands (one per team) or alternatives for presenting the posters,
-			\item organizing snacks and drinks, and
-			\item inviting officials, sponsors, the local organization, and the trustees of the RoboCup Federation to the event.
-		\end{enumerate}
-	\item \textbf{Poster presentation:} During the \WelcomeReception, the teams give a poster presentation on their research focus, recent results, and their scientific contribution.
-	Both the poster and the teaser talk are evaluated by a jury (see~\refsec{sec:poster_teaser_session}).
-\end{enumerate}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+% This Welcome Reception was suggested by the EC but it is not a technical aspect
+% It is still open for the TC to get it back is the EC strongly request it
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%\section{Welcome Reception}
+%\label{sec:welcome_reception}
+%Since Eindhoven 2013, RoboCup@Home holds an own \WelcomeReception{} in addition to the official opening ceremony. During the \WelcomeReception, a \PS{} is held in which teams present their research focus and latest results (see~\refsec{sec:poster_teaser_session}).
+%\begin{enumerate}
+%	\item \textbf{Time:} The \WelcomeReception{} is held in the evening of the last setup day.
+%	\item \textbf{Place:} The \WelcomeReception{} takes place in the @Home \Arena{} and/or in the \AtHome{} team area.
+%	\item \textbf{Snacks \& drinks:} During the \WelcomeReception{}, snacks and beverages (beers, sodas, etc.) are served.
+%	\item \textbf{Organization:} It is the responsibility of the OC and the local organizers to organize the \WelcomeReception{} and \PS{}, including:
+%		\begin{enumerate}
+%			\item organizing poster stands (one per team) or alternatives for presenting the posters,
+%			\item organizing snacks and drinks, and
+%			\item inviting officials, sponsors, the local organization, and the trustees of the RoboCup Federation to the event.
+%		\end{enumerate}
+%	\item \textbf{Poster presentation:} During the \WelcomeReception, the teams give a poster presentation on their research focus, recent results, and their scientific contribution.
+%	Both the poster and the teaser talk are evaluated by a jury (see~\refsec{sec:poster_teaser_session}).
+%\end{enumerate}
 
 \section{Poster Teaser Session}
 \label{sec:poster_teaser_session}
-Before the \WelcomeReception{} and \PS, a \iterm{Poster Teaser Session} is held. In this teaser session, each team can give a short presentation of their research and the poster being presented at the poster session.
+%Before the \WelcomeReception{} and \PS,
+A \iterm{Poster Teaser Session} is held. In this teaser session, each team can give a short presentation of their research and the poster being presented at the poster session.
 
 \subsection{Poster teaser session}
 \begin{enumerate}

--- a/Setup.tex
+++ b/Setup.tex
@@ -47,7 +47,7 @@ Depending on the schedule, the \iterm{Setup \& Preparation} phase lasts for one 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
 % This Welcome Reception was suggested by the EC but it is not a technical aspect
-% It is still open for the TC to get it back is the EC strongly request it
+% It is left commented for the TC to get it back if the EC strongly request it. 2023
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/general_rules/ContinueRules.tex
+++ b/general_rules/ContinueRules.tex
@@ -54,12 +54,12 @@ In the following example, a robot has to clean the table, but is unable to grasp
 There is no limit in the amount of times a robot can request human assistance, but score reduction applies every time it is requested.
 
 \begin{enumerate}
-	\item \textbf{Partial execution:} A reduction of 10\% of the maximum attainable score is applied when the robot request a partial solution (e.g. pointing to the person the robot is looking for or placing an object within grasping distance).
+	\item \textbf{Partial execution:} A reduction in the score is applied when the robot request a partial solution (e.g. pointing to the person the robot is looking for or placing an object within grasping distance).
 	The referee decides whether the requested action is simple enough to corresponds to a partial execution or not.
 
-	\item \textbf{Full awareness:} A reduction of 20\% of the maximum attainable score is applied when the robot is able to track and supervise activity, detecting possible, and when the requested action has been completed.
+	\item \textbf{Full awareness:} A reduction in the score is applied when the robot is able to track and supervise activity, detecting possible, and when the requested action has been completed.
 
-	\item \textbf{No awareness:} A reduction of 30\% of the maximum attainable score is applied when the robot has to be told when the requested action has been completed.
+	\item \textbf{No awareness:} A reduction in the score is applied when the robot has to be told when the requested action has been completed.
 
 	\item \textbf{Bonuses:} No bonus points can be scored when the robot requests help to solve part of a task that normally would grant a bonus.
 


### PR DESCRIPTION
Updated the definitions in Deus ex Machina section to avoid fixed scoring regulations and leave those to the specificites of each task and their own scoring systems.

Also, commented out the Welcome Reception subsection as it is not a technical aspect to be regulated in this rulebook. It has been left opened in case the EC strongly suggest to get it back.