### PR TITLE
(CML) dropping bag was socreitem instead of penalty

### DIFF
--- a/scoresheets/CarryMyLuggage.tex
+++ b/scoresheets/CarryMyLuggage.tex
@@ -16,7 +16,7 @@ The maximum time for this test is 5 minutes.
 
 
 	\scoreheading{Regular Penalties}
-	\scoreitem{50}{Dropping the bag}
+	\penaltyitem{50}{Dropping the bag}
 	
 	\scoreheading{Deus Ex Machina Penalties}
 	\penaltyitem{50}{Rediscovering the operator by natural interaction}


### PR DESCRIPTION
Closes https://github.com/RoboCupAtHome/RuleBook/issues/792

Changes proposed in this pull request:
- Fix dropping the bag during following being positively scored instead of penalized

This commit also needs to be cherry-picked in the `2023` branch
