### PR TITLE
Split rulebook

### DIFF
--- a/GeneralRules.tex
+++ b/GeneralRules.tex
@@ -20,17 +20,17 @@ This means that additional or contrary rules, in particular with respect to the 
 
 %\input{general_rules/Robots}
 
-\input{general_rules/ExternalDevices}
+%\input{general_rules/ExternalDevices}
 
 %\input{general_rules/Organization}
 
-\input{general_rules/Procedure}
+%\input{general_rules/Procedure}
 
 \input{general_rules/ContinueRules.tex}
 
 \input{general_rules/PenaltiesBonuses}
 
-\input{general_rules/OpenChallenge}
+%\input{general_rules/OpenChallenge}
 
 %\input{general_rules/ManipulationChallenge}
 % Local Variables:

--- a/Introduction.tex
+++ b/Introduction.tex
@@ -21,15 +21,15 @@ A set of benchmark tests is used to evaluate the abilities and performance of di
 The focus is on, but is not limited to, the following domains: human-robot interaction and cooperation, navigation and mapping in dynamic environments, computer vision and object recognition under natural light conditions, object manipulation, adaptive behaviors, behavior integration, ambient intelligence, standardization and system integration.
 The competition is co-located with the RoboCup symposium.
 
-\input{introduction/Organization}
+%\input{introduction/Organization}
 
-\input{introduction/Infrastructure}
+%\input{introduction/Infrastructure}
 
 \input{introduction/Leagues}
 
 \input{introduction/Competition}
 
-\input{introduction/Awards}
+%\input{introduction/Awards}
 
 % Local Variables:
 % TeX-master: "Rulebook"

--- a/Introduction.tex
+++ b/Introduction.tex
@@ -25,7 +25,7 @@ The competition is co-located with the RoboCup symposium.
 
 %\input{introduction/Infrastructure}
 
-\input{introduction/Leagues}
+%\input{introduction/Leagues}
 
 \input{introduction/Competition}
 

--- a/Organization.tex
+++ b/Organization.tex
@@ -50,6 +50,8 @@
 	\setcounter{page}{1}
 	\pagenumbering{arabic}
 	
+	\input{organization/Introduction}
+	\input{organization/GeneralRules}
 	\input{Setup}	
 	
 	\printabx

--- a/Organization.tex
+++ b/Organization.tex
@@ -1,0 +1,58 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%
+%%          $Id: Rulebook.tex 2014-12-12 balkce $
+%%    author(s): RoboCupAtHome Technical Committee(s)
+%%  description: introduction to RoboCupAtHome
+%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\documentclass[11pt, twoside, openright, a4paper, chapterprefix]{scrbook}
+\usepackage[inner=2.5cm, outer=2.5cm, top=4cm, bottom=4cm]{geometry}
+
+%%% PACKAGES %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\input{./setup/packages.tex}
+\input{./setup/config.tex}
+\input{./setup/styling.tex}
+
+
+%%% MACROS %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\input{./setup/active_version.tex}
+\graphicspath{{\YEAR/}{./images/}}
+\input{./setup/macros.tex}
+\input{./setup/abbrevix.tex}
+
+
+
+\makeindex                                % generate index
+\makeabbex                                % generate abbreviations
+
+
+
+
+
+%\newcommand{\sectionbreak}{\clearpage}
+%\newcommand{\subsectionbreak}{\clearpage}
+
+
+\begin{document}
+	
+	\input{./pages/titlepage}
+	
+	\setcounter{page}{0}
+	\pagenumbering{roman}
+	\pagestyle{empty}
+	\input{./pages/acknowledgments}
+	\clearpage
+	
+	\pagestyle{plain}
+	\tableofcontents
+	\clearpage
+	
+	\setcounter{page}{1}
+	\pagenumbering{arabic}
+	
+	\input{Setup}	
+	
+	\printabx
+	\printidx
+	
+\end{document}

--- a/Roadmap.tex
+++ b/Roadmap.tex
@@ -1,0 +1,60 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%
+%%          $Id: Rulebook.tex 2014-12-12 balkce $
+%%    author(s): RoboCupAtHome Technical Committee(s)
+%%  description: introduction to RoboCupAtHome
+%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\documentclass[11pt, twoside, openright, a4paper, chapterprefix]{scrbook}
+\usepackage[inner=2.5cm, outer=2.5cm, top=4cm, bottom=4cm]{geometry}
+
+%%% PACKAGES %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\input{./setup/packages.tex}
+\input{./setup/config.tex}
+\input{./setup/styling.tex}
+
+
+%%% MACROS %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\input{./setup/active_version.tex}
+\graphicspath{{\YEAR/}{./images/}}
+\input{./setup/macros.tex}
+\input{./setup/abbrevix.tex}
+
+
+
+\makeindex                                % generate index
+\makeabbex                                % generate abbreviations
+
+
+
+
+
+%\newcommand{\sectionbreak}{\clearpage}
+%\newcommand{\subsectionbreak}{\clearpage}
+
+
+\begin{document}
+	
+	\input{./pages/titlepage}
+	
+	\setcounter{page}{0}
+	\pagenumbering{roman}
+	\pagestyle{empty}
+	\input{./pages/acknowledgments}
+	\clearpage
+	
+	\pagestyle{plain}
+	\tableofcontents
+	\clearpage
+	
+	\setcounter{page}{1}
+	\pagenumbering{arabic}
+	
+	\input{CompetitionConcepts}
+	
+	
+	
+	\printabx
+	\printidx
+	
+\end{document}

--- a/organization/GeneralRules.tex
+++ b/organization/GeneralRules.tex
@@ -12,27 +12,26 @@ These are the general rules and regulations for the competition in the \RoboCup\
 Every rule in this section can be considered to implicitly include the term \emph{\enquote{unless stated otherwise}}.
 This means that additional or contrary rules, in particular with respect to the specification of tests, have a higher priority than those mentioned in the general rules and regulations.
 
-%\input{general_rules/TeamRegistration}
+\input{general_rules/TeamRegistration}
 
-%\input{general_rules/vizbox}
+\input{general_rules/vizbox}
 
-\input{general_rules/Scenario}
+%\input{general_rules/Scenario}
 
-%\input{general_rules/Robots}
+\input{general_rules/Robots}
 
-\input{general_rules/ExternalDevices}
+%\input{general_rules/ExternalDevices}
 
-%\input{general_rules/Organization}
+\input{general_rules/Organization}
 
-\input{general_rules/Procedure}
+%\input{general_rules/Procedure}
 
-\input{general_rules/ContinueRules.tex}
+%\input{general_rules/ContinueRules.tex}
 
-\input{general_rules/PenaltiesBonuses}
+%\input{general_rules/PenaltiesBonuses}
 
-\input{general_rules/OpenChallenge}
+%\input{general_rules/OpenChallenge}
 
-%\input{general_rules/ManipulationChallenge}
 % Local Variables:
 % TeX-master: "Rulebook"
 % End:

--- a/organization/GeneralRules.tex
+++ b/organization/GeneralRules.tex
@@ -20,17 +20,17 @@ This means that additional or contrary rules, in particular with respect to the 
 
 \input{general_rules/Robots}
 
-%\input{general_rules/ExternalDevices}
+\input{general_rules/ExternalDevices}
 
 \input{general_rules/Organization}
 
-%\input{general_rules/Procedure}
+\input{general_rules/Procedure}
 
 %\input{general_rules/ContinueRules.tex}
 
 %\input{general_rules/PenaltiesBonuses}
 
-%\input{general_rules/OpenChallenge}
+\input{general_rules/OpenChallenge}
 
 % Local Variables:
 % TeX-master: "Rulebook"

--- a/organization/Introduction.tex
+++ b/organization/Introduction.tex
@@ -11,7 +11,7 @@
 
 \input{introduction/Infrastructure}
 
-%\input{introduction/Leagues}
+\input{introduction/Leagues}
 
 %\input{introduction/Competition}
 

--- a/organization/Introduction.tex
+++ b/organization/Introduction.tex
@@ -1,0 +1,22 @@
+%% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%
+%%    author(s): RoboCupAtHome Technical Committee(s)
+%%  description: Introduction
+%%
+%% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\chapter{Introduction}
+\label{chap:introduction}
+
+\input{introduction/Organization}
+
+\input{introduction/Infrastructure}
+
+%\input{introduction/Leagues}
+
+%\input{introduction/Competition}
+
+\input{introduction/Awards}
+
+% Local Variables:
+% TeX-master: "Rulebook"
+% End:

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -52,11 +52,11 @@
 
 \input{Introduction}
 
-\input{CompetitionConcepts}
+%\input{CompetitionConcepts}
 
 \input{GeneralRules}
 
-\input{Setup}
+%\input{Setup}
 
 
 


### PR DESCRIPTION
** Note: Your contribution is expected to meet the conventions and policies described in the [contribution guidelines](https://github.com/RoboCupAtHome/RuleBook/wiki/Guidelines:-Contributing) **

## Description
Splits rulebook into the rules and organization of the competition. This makes for a briefer rulebook and hopefully a better intro for new teams.

Closes issue #

Changes proposed in this pull request:
- split rules and organization into two documents
-
-

## Other comments
If this request is marked as a draft, please describe your plans or any specific feedback you would like

Todo:

- [ ] Edit the documents to be legible on their own. 