### PR TITLE
[state-machine] added rules for communication

### DIFF
--- a/tasks/ServeBreakfast.tex
+++ b/tasks/ServeBreakfast.tex
@@ -52,6 +52,8 @@ The robot has to set a table for breakfast for one person and prepare cereal for
 \subsection*{Additional Rules and Remarks}
 \begin{enumerate}[nosep]
 	\item \textbf{Safe placing:} Objects must be placed with care, namely the robot should place rather than throw or drop objects.
+	\item \textbf{Specific Communication Guidelines}: The robot must use precise and detailed language when interacting with humans. For example, instead of saying, "Please give me the milk," it should say, "Please give me the milk carton located on the top-right shelf, third row."
+	\item \textbf{Advanced Visual Perception Standards: }The robot must display its internal perception data on its own screen, or VizBox, enabling referees to visually verify what the robot detects during the task.
 	\item \textbf{Deus ex Machina:} The scores are reduced if human assistance is received, in particular for:
 	\begin{itemize}[nosep]
 		\item pointing to an object or telling to the robot where an object is or where to place it
@@ -74,6 +76,7 @@ The referee needs to:
 \begin{itemize}
 	\item Remove all objects from the table.
 	\item Place all objects in their default locations.
+	\item Referees will strictly enforce communication guidelines. Non-specific requests by the robot will be disregarded.
 \end{itemize}
 
 % \newpage


### PR DESCRIPTION
## Description
We have introduced new rules for communication and added visualization guidance in the "Serve Breakfast" challenge. These changes are aimed at fostering a more dynamic and less state-machine-dependent approach.

Communication Enhancements
Detailed Interaction: Robots are required to use specific and detailed language in their requests. Generic phrases like "please give me [object]" are unacceptable.
Example: A robot should say, "Please hand me the milk carton from the top-right shelf, third row," instead of a vague request.
Referee Role: Referees will enforce these communication standards strictly. Requests that lack specificity will be ignored.
Visualization Guidance
Perception Display: Robots must have a mechanism to display their internal perception data. This ensures referees can visually confirm what the robot is perceiving.

Closes issue #
Addresses issue: https://github.com/RoboCupAtHome/RuleBook/issues/805#issue-1829292526

Changes proposed in this pull request:
- {Specific Communication Guidelines}
- {Advanced Visual Perception Standards: }

## Other comments
This is only for one challenge; this guideline will be done for every challenge.