### PR TITLE
Suggestion: Everyone should Score + Partial Scoring

### DIFF
--- a/scoresheets/CarryMyLuggage.tex
+++ b/scoresheets/CarryMyLuggage.tex
@@ -3,14 +3,16 @@ The maximum time for this test is 5 minutes.
 
 \begin{scorelist}
 	\scoreheading{Main Goal}
-	\scoreitem{100}{Picking up the correct bag}
-	\scoreitem{300}{Following the person to the car}
+	\scoreitem{15}{Perceiving the correct beg (visualize on screen or say which one)}
+	\scoreitem{30}{Picking up the correct bag}
+	\scoreitem{100}{Following the person to the car}
     \scoreitem{50}{Avoiding the crowd of people obstructing the path}
 	\scoreitem{50}{Avoiding the small object on the ground}
 	\scoreitem{50}{Avoiding the hard-to-see object}
 	\scoreitem{50}{Avoiding the area blocked with retractable barriers}
 	
 	\scoreheading{Bonus rewards}
+	\scoreitem{300}{Successful task completion}
 	\scoreitem{100}{Re-entering the arena}
 	\scoreitem{300}{Joining and staying in the queue on the way to the arena}
 

--- a/scoresheets/CleanTable.tex
+++ b/scoresheets/CleanTable.tex
@@ -2,14 +2,21 @@ The maximum time for this test is 10 minutes.
 
 \begin{scorelist}
 	\scoreheading{Main Goal}
-	\scoreitem[5]{60}{Picking tableware and cutlery for transportation to the dishwasher}
-	\scoreitem[5]{180}{Placing the tableware and cutlery inside the dishwasher}
+	\scoreitem{15}{Navigate to the table to pick up items}
+	\scoreitem[2]{30}{Picking tableware (cup, bowl) for transportation to the dishwasher}
+	\scoreitem{50}{Picking up a plate for transportation to the dishwasher}
+	\scoreitem[2]{50}{Picking up cutlery (spoon, fork) for transportation to the dishwasher}
+	\scoreitem[5]{30}{Placing the tableware and cutlery inside the dishwasher}
+	\scoreitem[5]{30}{Placing an item correctly (cleanable, convenient like a human would) in the dishwasher}
 
 	\scoreheading{Bonus Rewards}
-	\scoreitem{200}{Opening the dishwasher door}
+	\scoreitem[5]{100}{Task completion: for every successful pick \& place of a tableware or cutlery object}
 	\scoreitem{100}{Pulling out the dishwasher rack}
-	\scoreitem[5]{40}{Placing an item correctly in the dishwasher}
-	\scoreitem{300}{Placing the dishwasher tab inside the dishwasher's hatch intended for the tab}
+	\scoreitem{100}{Pushing in the dishwasher rack}
+	\scoreitem{200}{Opening the dishwasher door}
+	\scoreitem{200}{Closing the dishwasher door}
+	\scoreitem{100}{Picking up the dishwasher tab for transportation to the dishwasher}
+	\scoreitem{200}{Placing the dishwasher tab inside the dishwasher's hatch intended for the tab}
 
 	\scoreheading{Deus Ex Machina Penalties}
 	\penaltyitem[5]{20}{Pointing at an object or telling the robot where an object is}

--- a/scoresheets/Receptionist.tex
+++ b/scoresheets/Receptionist.tex
@@ -2,15 +2,21 @@ The maximum time for this test is 5 minutes.
 
 \begin{scorelist}[startbutton=false]
 	\scoreheading{Main Goal}
-	\scoreitem[2]{250}{Introduce a new guest to every other guest and offer a seat}
-	\scoreitem{50}{Look at the person talking}
-	\scoreitem{50}{Look at the person the robot is introducing the guest to}
-	\scoreitem{50}{Look in the direction of navigation}
-	\penaltyitem[2]{50}{Continue with wrong name or drink}
-	\penaltyitem[2]{50}{Persistent inappropriate gaze - away from conversational partner}
-	\penaltyitem[1]{50}{Persistent gaze not in the direction of the navigation while moving}
+	\scoreitem[2]{15}{Navigate to the door, when the door bell rings}
+	\scoreitem[2]{15}{Guide the guest to the other guests (navigate to the guest group)}
+	\scoreitem[2]{10}{Look in the direction of navigation or at the navigation goal.}
+	\scoreitem[2]{50}{Introduce a new guest to every other guest}
+	\scoreitem[2]{50}{Offer a free seat to the new guest}
+	\scoreitem[2]{25}{Look at the person talking}
+	\scoreitem[2]{50}{Look at the person the robot is introducing the guest to}
+
+	\scoreheading{Penalties}
+	\penaltyitem{50}{Wrong guest information was memorized (continue with wrong name or drink)}
+	\penaltyitem{50}{Persistent inappropriate gaze (away from conversational partner)}
+	\penaltyitem{10}{Persistent gaze not in the direction of the navigation while moving.}
 
 	\scoreheading{Bonus Rewards}
+	\scoreitem[2]{200}{Successful task completion per guest}
 	\scoreitem[2]{100}{Open the entrance door for a guest}
 	\scoreitem{150}{Describe the first guest to the second guest}
 	

--- a/scoresheets/Restaurant.tex
+++ b/scoresheets/Restaurant.tex
@@ -9,7 +9,8 @@
 	\scoreitem[2]{100}{Detect calling or waving customer}
 	\scoreitem[2]{100}{Reach a customer's table without prior guidance/training}
 
-	\scoreitem[2]{600}{Take and serve an order.}
+	\scoreitem[2]{300}{Take and serve an order.}
+	\scoreitem[2]{300}{Serve an order.}
 
 	\scoreheading{Bonus Rewards}
 	\scoreitem[2]{200}{Use an unattached tray to transport}

--- a/scoresheets/ServeBreakfast.tex
+++ b/scoresheets/ServeBreakfast.tex
@@ -2,24 +2,27 @@ The maximum time for this test is 5 minutes.
 
 \begin{scorelist}
 	\scoreheading{Main Goal}
-	\scoreitem[4]{15}{Picking up breakfast items for transportation to the table}
-	\scoreitem[4]{60}{Placing breakfast items on the table}
-	\scoreitem{300}{Pouring cereal into the bowl}
+	\scoreitem{15}{Initial navigation to pick up area}
+	\scoreitem[4]{15}{Perceiving object and categorizing it correctly (visualize or say)}
+	\scoreitem[4]{30}{Picking up breakfast items for transportation to the table}
+	\scoreitem[4]{30}{Placing breakfast items on the table}
+	\scoreitem{100}{Pouring cereal into the bowl}
 
 	\scoreheading{Bonus Rewards}
-	\scoreitem{300}{Pouring milk into the bowl}
+	\scoreitem[4]{100}{Task completion: Every successfully completed pick \& place action}
+	\scoreitem{100}{Pouring milk into the bowl}
 	\scoreitem{100}{Placing a spoon next to the bowl}
 
 	\scoreheading{Regular Penalties}
 	\penaltyitem[4]{30}{Throwing or dropping an object on the table}
-	\penaltyitem{100}{Spilling cereal while pouring}
-	\penaltyitem{150}{Spilling milk while pouring}
+	\penaltyitem{50}{Spilling cereal while pouring}
+	\penaltyitem{50}{Spilling milk while pouring}
 
 	\scoreheading{Deus Ex Machina Penalties}
 	\penaltyitem[4]{5}{Pointing at an object}
-	\penaltyitem[4]{15}{Handing an object over to the robot}
+	\penaltyitem[4]{20}{Handing an object over to the robot}
 	\penaltyitem[4]{60}{A human placing an object on the table}
-	\penaltyitem{300}{A human pouring cereal in the bowl}
+	\penaltyitem{100}{A human pouring cereal in the bowl}
 
 	%\setTotalScore{1000}
 \end{scorelist}

--- a/scoresheets/StoringGroceries.tex
+++ b/scoresheets/StoringGroceries.tex
@@ -3,11 +3,16 @@ The maximum time for this test is 5 minutes.
 
 \begin{scorelist}
 	\scoreheading{Main Goal}
+	\scoreitem{15}{Navigating to the table}
+	\scoreitem[5]{15}{Perceiving object and categorizing it correctly (visualize or say)}
 	\scoreitem[5]{30}{Picking up an object for transportation to the cabinet}
-	\scoreitem[5]{90}{Moving an object next to similar objects on the cabinet}
+	\scoreitem[5]{15}{Perceiving objects in shelf and saying on which layer the currently handled object should be placed (visualize or say)}
+	\scoreitem[5]{15}{Placing an object in the cabinet}
+	\scoreitem[5]{30}{Placing an object next to similar objects on the cabinet}
 
 	\scoreheading{Bonus Rewards}
-	\scoreitem{200}{Opening the cabinet door without human help}
+	\scoreitem[5]{100}{Task completion: Every successfully completed pick \& place action}
+	\scoreitem{100}{Opening the cabinet door without human help}
 	\scoreitem{100}{Picking and placing a tiny object}
 	\scoreitem{100}{Picking and placing a heavy object}
 
@@ -15,7 +20,7 @@ The maximum time for this test is 5 minutes.
 	\penaltyitem[5]{-60}{Storing an object without categorizing it correctly}
 
 	\scoreheading{Deus Ex Machina Penalties}
-	\penaltyitem[5]{-30}{A human handing an object over to the robot}
+	\penaltyitem[5]{-40}{A human handing an object over to the robot}
 	\penaltyitem[5]{-90}{A human placing an object in the cabinet}
 	\penaltyitem[5]{-30}{A human placing an object in the cabinet at a location clearly indicated by the robot}
 	\penaltyitem[5]{-45}{A human pointing at a target location}


### PR DESCRIPTION
** Note: Your contribution is expected to meet the conventions and policies described in the [contribution guidelines](https://github.com/RoboCupAtHome/RuleBook/wiki/Guidelines:-Contributing) **

## Description
An attempt to tackle the issues of "Teams should score" and "Partial Points". The changes mostly concern Stage 1 points, in order to give newcomers a chance of scoring, while also giving bonus points for completing (sub) tasks, in order to encourage trying to solve the entire task and not just farm partial points. We kept the Stage 2 grading almost as it was, since the generic way of how the task rewards are phrased, is fitting for the advanced challenges.
Mostly the approach contains splitting up actions into partial steps to allow giving points for perception or picking up of objects, so that teams can still get points even if something goes wrong during e.g. placing.
The total points of the tasks do not total to round numbers - but it was decided to disregard this for now.

PDF for ease of view: [rulebook.pdf](https://github.com/RoboCupAtHome/RuleBook/files/13888462/rulebook.pdf)

Closes issue #
https://github.com/RoboCupAtHome/RuleBook/issues/804 - Teams should score
https://github.com/RoboCupAtHome/RuleBook/issues/808 - Partial Scoring

Changes proposed in this pull request:
- give points for completing parts of the challenges
- give bonus points for completing the entire task to encourage task completion
- points farming (e.g. just picking up objects and dropping them again) is not allowed

## Other comments
If this request is marked as a draft, please describe your plans or any specific feedback you would like