### PR TITLE
[Draft] organization doc restructure

### DIFF
--- a/CompetitionConcepts.tex
+++ b/CompetitionConcepts.tex
@@ -3,7 +3,7 @@
 
 A set of conceptual key criteria builds the basis for the \textsc{RoboCup@Home} competition.
 These criteria are to be understood as a common agreement on the general concept of the competition.
-The concrete rules are listed in Chapter~\ref{chap:rules}.
+The concrete rules are listed in the \AtHome{} Rules \& Regulations document.
 
 \section{Lean Set of Rules}
 \label{concept:lean_set_of_rules}
@@ -68,7 +68,7 @@ The competition should be attractive for the audience and the public; thus, high
 While they have to compete against each other during the competition, the members of the \AtHome{} league are expected to cooperate and exchange knowledge to advance technology together.
 The \iterm{RoboCup@Home mailing list} as well as the \RR{} can be used to get in touch with other teams and to discuss league-specific issues such as rule changes, proposals for new tests, etc.
 % Since 2007 there is also the \iterm{RoboCup@Home Wiki} (see~\refsec{sec:at_home_wiki}) which serves as a central place to collect information relevant for the @Home league.
-In addition, every team is expected to share relevant technical, scientific (and team-related) information in their TDP (see~\refsec{rule:website_tdp}) and on the team's website.
+In addition, every team is expected to share relevant technical, scientific (and team-related) information in a scientific paper and on the team's website.
 
 Finally, all teams are invited to submit papers on related research to the \Symp{}, which accompanies the annual RoboCup World Championship.
 

--- a/documents/organization.tex
+++ b/documents/organization.tex
@@ -51,8 +51,9 @@
 	\pagenumbering{arabic}
 
 	\input{organization/Introduction}
-	\input{organization/GeneralRules}
-	\input{organization/Setup}
+	\input{CompetitionConcepts}
+	%\input{organization/GeneralRules}
+	%\input{organization/Setup}
 
 	\printabx
 	\printidx

--- a/documents/rulebook.tex
+++ b/documents/rulebook.tex
@@ -60,6 +60,8 @@
 
 \input{rulebook_pages/GeneralRules}
 
+\input{organization/Setup}
+
 %\input{Setup}
 
 

--- a/general_rules/ContinueRules.tex
+++ b/general_rules/ContinueRules.tex
@@ -111,9 +111,6 @@ Preferably, the alternative HRI must be also adapted to the user.
 Consider localization (with English as the default), but also potential users of service robots at their home.
 For example: elderly people and people with physical disabilities.
 
-\textbf{\textsc{Award:}} The best alternative is awarded the Best Human-Robot Interface award (\refsec{award:hri}).
-
-
 % Local Variables:
 % TeX-master: "../Rulebook"
 % End:

--- a/general_rules/OpenChallenge.tex
+++ b/general_rules/OpenChallenge.tex
@@ -11,5 +11,5 @@ On the first two competition days after the end of the regular test blocks, team
 	\item \textbf{Arena Changes:} The team can rearrange the arena when their time slot starts, but all changes need to be reverted as soon as their time slot ends.
 	\item \textbf{Focus:} While the demonstrations are intended to share research insights, we still want to see robots performing; in particular, the \OpenChallenge{} should not be turned into a pure academic lecture.
 	\item \textbf{Leagues:} Ideally, the open challenges of all \AtHome{} leagues will be scheduled consecutively so that everyone has an opportunity to see all demonstrations; however, in case more than 12 participants across the leagues register for the \OpenChallenge, each league will hold their \OpenChallenge{} concurrently.
-	\item \textbf{Award:} The \OpenChallenge{} does not contribute any points towards the official competition score, but participating teams are eligible to receive the \OCAward{} (see \ref{award:oc}).
+	\item \textbf{Award:} The \OpenChallenge{} does not contribute any points towards the official competition score, but participating teams are eligible to receive the \OCAward{}.
 \end{enumerate}

--- a/general_rules/PenaltiesBonuses.tex
+++ b/general_rules/PenaltiesBonuses.tex
@@ -2,7 +2,6 @@
 \newcommand{\penaltybig}{500~}
 \newcommand{\penaltysmall}{250~}
 
-
 \section{Special penalties and bonuses}\label{sec:special_awards}
 
 \subsection{Penalty for not attending}\label{rule:not_attending}
@@ -17,7 +16,7 @@
 
 \subsection{Extraordinary penalties}\label{rule:extraordinary_penalties}
 \begin{enumerate}
-	\item \textbf{Penalty for cheating:} If a team member is found cheating or breaking the Fair Play rule (see \refsec{rule:fairplay}), the team will be automatically disqualified of the running test, and a penalty of \scoring{\penaltybig points} is handed out.
+	\item \textbf{Penalty for cheating:} If a team member is found cheating or breaking Fair Play rule (see \refsec{rule:fairplay}), the team will be automatically disqualified of the running test, and a penalty of \scoring{\penaltybig points} is handed out.
 	The \iaterm{Technical Committee}{TC} may also disqualify the team for the entire competition.
 
 	\item \textbf{Penalty for faking robots:} If a team starts a test, but it does not solve any of the partial tasks (and is obviously not trying to do so), a penalty of \scoring{\penaltysmall points} is handed out.

--- a/introduction/Awards.tex
+++ b/introduction/Awards.tex
@@ -48,7 +48,7 @@ There is no \HRIAward{} in case the EC decides that there is no outstanding inte
 To foster scientific knowledge exchange and reward the teams' efforts to present their research contributions, all scientific posters of each league are evaluated and have the chance of receiving the \DSPLPosterAward, the \OPLPosterAward, or the \SSPLPosterAward, respectively.
 
 Candidate posters must present innovative and state-of-the-art research within a field with a direct application to \AtHome, and demonstrate successful and clear results in an easy-to-understand way.
-In addition to being attractive and well-rated in the \PS{} (see~\refsec{sec:poster_teaser_session}), the described research must have impact in the team's performance during the competition.
+In addition to being attractive and well-rated in the \PS{}, the described research must have impact in the team's performance during the competition.
 
 The \AtHome{} EC members nominate a set of candidates for the award and the TC elects the winner.
 A TC member whose team is among the nominees is not allowed to vote.
@@ -86,7 +86,7 @@ Since Nagoya 2017, RoboCup@Home awards the best contribution to the community by
 To be eligible for the award, the software must be easy to read, have proper documentation, follow standard design patterns, be actively maintained, and meet the IEEE software engineering metrics of scalability, portability, maintainability, fault tolerance, and robustness.
 In addition, the open sourced software must be made available as a framework-independent standalone library so it can be reused with any software architecture.
 
-Candidates must send their application to the TC at least one month before the competition by means of a short paper (maximum 4 pages), following the same format used for the \TDP{} (see~\refsec{rule:website_tdp}), including a brief explanation of the approach, comparison with state-of-the-art techniques, statement of the used metrics and software design patterns, and the name of the teams and other collaborators that are also using the software being described.
+Candidates must send their application to the TC at least one month before the competition by means of a short paper (maximum 4 pages), following the same format used for the \TDP{}, including a brief explanation of the approach, comparison with state-of-the-art techniques, statement of the used metrics and software design patterns, and the name of the teams and other collaborators that are also using the software being described.
 
 The \AtHome{} TC members nominate a set of candidates for the award and the EC elects the winner.
 An EC/TC member whose team is among the nominees is not allowed to vote.

--- a/organization/GeneralRules.tex
+++ b/organization/GeneralRules.tex
@@ -18,19 +18,19 @@ This means that additional or contrary rules, in particular with respect to the 
 
 %\input{general_rules/Scenario}
 
-\input{general_rules/Robots}
+%\input{general_rules/Robots}
 
-\input{general_rules/ExternalDevices}
+%\input{general_rules/ExternalDevices}
 
 \input{general_rules/Organization}
 
-\input{general_rules/Procedure}
+%\input{general_rules/Procedure}
 
 %\input{general_rules/ContinueRules.tex}
 
-\input{general_rules/PenaltiesBonuses}
+%\input{general_rules/PenaltiesBonuses}
 
-\input{general_rules/OpenChallenge}
+%\input{general_rules/OpenChallenge}
 
 % Local Variables:
 % TeX-master: "Rulebook"

--- a/rulebook_pages/GeneralRules.tex
+++ b/rulebook_pages/GeneralRules.tex
@@ -12,25 +12,24 @@ These are the general rules and regulations for the competition in the \RoboCup\
 Every rule in this section can be considered to implicitly include the term \emph{\enquote{unless stated otherwise}}.
 This means that additional or contrary rules, in particular with respect to the specification of tests, have a higher priority than those mentioned in the general rules and regulations.
 
-%\input{general_rules/TeamRegistration}
+\input{general_rules/TeamRegistration}
 
-%\input{general_rules/vizbox}
+\input{general_rules/vizbox}
 
 \input{general_rules/Scenario}
 
-%\input{general_rules/Robots}
+\input{general_rules/Robots}
 
-%\input{general_rules/ExternalDevices}
+\input{general_rules/ExternalDevices}
 
-%\input{general_rules/Organization}
+\input{general_rules/Organization}
 
-%\input{general_rules/Procedure}
+\input{general_rules/Procedure}
 
-\input{general_rules/ContinueRules.tex}
+\input{general_rules/ContinueRules}
+\input{general_rules/PenaltiesBonuses}
 
-%\input{general_rules/PenaltiesBonuses}
-
-%\input{general_rules/OpenChallenge}
+\input{general_rules/OpenChallenge}
 
 %\input{general_rules/ManipulationChallenge}
 % Local Variables:

--- a/scoresheets/Receptionist.tex
+++ b/scoresheets/Receptionist.tex
@@ -9,7 +9,7 @@ The maximum time for this test is 5 minutes.
 	\scoreitem[2]{100}{Offer a free seat to the new guest}
 	\scoreitem[2]{25}{Look at the person talking}
 	\scoreitem[2]{50}{Look at the person the robot is introducing the guest to}
-	\scoreitem{50}{Qualitative robot social performance (see sec. ~\ref{rule:perceived_intelligence})}
+	\scoreitem{50}{Qualitative robot social performance \ifShortScoresheet{(see sec.~\ref{rule:perceived_intelligence})}}
 	
 	\scoreheading{Bonus Rewards}
 	\scoreitem[2]{100}{Open the entrance door for a guest}

--- a/scoresheets/Restaurant.tex
+++ b/scoresheets/Restaurant.tex
@@ -11,7 +11,7 @@
 
 	\scoreitem[2]{300}{Take an order.}
 	\scoreitem[2]{300}{Serve an order.}
-	\scoreitem{50}{Qualitative robot social performance (see sec. ~\ref{rule:perceived_intelligence})}
+	\scoreitem{50}{Qualitative robot social performance \ifShortScoresheet{(see sec.~\ref{rule:perceived_intelligence})}}
 
 	\scoreheading{Bonus Rewards}
 	\scoreitem[2]{200}{Use an unattached tray to transport}

--- a/setup/macros_scoresheets.tex
+++ b/setup/macros_scoresheets.tex
@@ -560,7 +560,8 @@
 
 	% require signal for door opening %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	\ifthenelse{ \equal{\scorelistStartButton}{true} }{
-	  \penaltyitem{\scorelistStartButtonPenalty}{Using alternative start signal \ifShortScoresheet{(see sec.~\ref{rule:start_signal})}{}}
+	  \penaltyitem{\scorelistStartButtonPenalty}{Using alternative start signal \ifShortScoresheet{(see sec.~\ref{rule:start_signal})}
+	  {}}
 	}{}
 
 	% data recording bonus %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Rulebook release has a bunch of missing refs due to the rulebook splitup.

![310188234-9d4f18fe-f1b6-4204-8e43-0ef1da19bfe5](https://github.com/RoboCupAtHome/RuleBook/assets/14273072/fbf75e86-b227-48b2-ba73-1c7c1a9c5c09)



This fixes that, but:

- readded bonus/penalties section to rulebook (for scoresheet refs)
- removed some ref for now as we need to add `start_signa`l but that refers` inspection` which refers `robot` sections. I dont know what to move where so removed the refs for now


