### PR TITLE
Receptionist typo and remove references to age and gender

### DIFF
--- a/tasks/Receptionist.tex
+++ b/tasks/Receptionist.tex
@@ -44,7 +44,7 @@ The robot has to take two new guests to the living room to introduce them and of
 	
 	\item \textbf{Switching Places:} Guests may switch places after they were seated.
 	
-	\item \textbf{Describing the First Guest:} Naming at least 4 characteristics of the first guest, i.e., color of clothes, color of hair, gender, and age, earns bonus points.
+	\item \textbf{Describing the First Guest:} Naming at least 4 characteristics of the first guest, such as color of clothes/hair, earns bonus points.
 	\item \textbf{Looking at person/direction of navigation:} During verbal interactions and descriptions of people, robot 
 	looks at the conversational partner. Robot can point at the person being introduce/described or alternate gaze between two people. During navigation robot looks in the direction where it is going. Persistently gazing towards unrelated 
 	person or incorrect direction while moving during the task deducts points. 

--- a/tasks/Receptionist.tex
+++ b/tasks/Receptionist.tex
@@ -80,7 +80,7 @@ The referees need to:
 
 During setup day:
 \begin{itemize}
-	\item Provide the dorbell sound.
+	\item Provide the doorbell sound.
 \end{itemize}
 
 At least two hours before test:


### PR DESCRIPTION
Small PR fixing a typo in the `Receptionist` task, and removing reference to age and gender (as has been done in GPSR, see #841).