### PR TITLE
Fix broken scoring for storing groceries.

### DIFF
--- a/scoresheets/StoringGroceries.tex
+++ b/scoresheets/StoringGroceries.tex
@@ -19,11 +19,9 @@ The maximum time for this test is 5 minutes.
 	\penaltyitem[5]{-60}{Storing an object without categorizing it correctly}
 
 	\scoreheading{Deus Ex Machina Penalties}
-	\penaltyitem[5]{-15}{A human handing an object over to the robot (the object is clearly indicated by the robot)}
 	\penaltyitem[5]{-30}{A human handing an object over to the robot}
-	\penaltyitem[5]{-45}{A human placing an object in the cabinet at a location clearly indicated by the robot}
-	\penaltyitem[5]{-90}{A human placing an object in the cabinet}
-	\penaltyitem[5]{-30}{A human placing an object in the cabinet at a location clearly indicated by the robot}
+	\penaltyitem[5]{-10}{A human placing an object in the cabinet}
+	\penaltyitem[5]{-30}{A human placing an object in the cabinet next to similar objects}
 	\penaltyitem[5]{-45}{A human pointing at a target location}
 \end{scorelist}
 

--- a/scoresheets/StoringGroceries.tex
+++ b/scoresheets/StoringGroceries.tex
@@ -19,10 +19,10 @@ The maximum time for this test is 5 minutes.
 	\penaltyitem[5]{-60}{Storing an object without categorizing it correctly}
 
 	\scoreheading{Deus Ex Machina Penalties}
-	\penaltyitem[5]{-30}{A human handing an object over to the robot}
-	\penaltyitem[5]{-10}{A human placing an object in the cabinet}
+	\penaltyitem[5]{-50}{A human handing an object over to the robot}
+	\penaltyitem[5]{-15}{A human placing an object in the cabinet}
 	\penaltyitem[5]{-30}{A human placing an object in the cabinet next to similar objects}
-	\penaltyitem[5]{-45}{A human pointing at a target location}
+	\penaltyitem[5]{-25}{A human pointing at a target location}
 \end{scorelist}
 
 


### PR DESCRIPTION
## Description

Closes issue #855

Changes proposed in this pull request:
- DeuxEx rules now mandate 'clear indication' so we should remove that part
- removed duplicate penalty item

I tried to somewhat match penalties to the scores but i am not sure of the original intention

