### PR TITLE
German Open Feedback for Restaurant

### DIFF
--- a/scoresheets/Restaurant.tex
+++ b/scoresheets/Restaurant.tex
@@ -21,8 +21,8 @@
 
 	\scoreheading{Deus ex Machina Penalties}
 	\penaltyitem[2]{200}{Being guided to a table}
-	\penaltyitem[4]{100}{Asking the Barman to handover object to the robot}
-	\penaltyitem[4]{100}{Guest needing to take the object from a tray or the robot's hand}
+	\penaltyitem[4]{50}{Asking the Barman to handover object to the robot}
+	\penaltyitem[4]{50}{Guest needing to take the object from a tray or the robot's hand}
 	\penaltyitem[2]{100}{Being told/pointed where is a table/\textit{Kitchen-bar}}
 
 \end{scorelist}

--- a/tasks/Restaurant.tex
+++ b/tasks/Restaurant.tex
@@ -77,7 +77,7 @@ This task focuses on
 		\item If a person from the audience (severely) interferes with the robot in a way that makes it impossible to solve the task, the teams may repeat the test immediately.
 		\item Each Deus Ex Machina penalty for skipping manipulation will only be applied twice per order so receiving an order with three objects is not more punishing.
 		\item If the robot detects a customer but does not reach their table, the robot must clearly show who was detected to receive points, i.e. displaying a picture of the person.
-		\item When a team is at the front of the queue, they are allowed to start their mapping procedure (the robot must remain in place). When it is their turn, they must bring the robot directly and in a straight line from the front of the queue to the start location. Once at the start location only slight movements are allowed (no moving back and forth, no full rotations etc.)
+		\item When a team is at the front of the queue, they are allowed to begin their startup procedure (the robot must remain in place). When it is their turn, they must bring the robot directly and in a straight line from the front of the queue to the start location. Once at the start location only slight movements are allowed (no moving back and forth, no full rotations etc.)
 	\end{itemize}
 	\item \textbf{Disqualification:}
 	\begin{itemize}

--- a/tasks/Restaurant.tex
+++ b/tasks/Restaurant.tex
@@ -71,7 +71,8 @@ This task focuses on
 		\item The robot can request to be guided to a customer's table.
 		\item The robot can choose to take several orders and place them later on, place an order and pick the next one while the former is being served, or dispatch one order at a time.
 		\item The robot can either transport each object individually, or using a tray. All delivered objects must be placed on the customer's table.
-		\item By default, the barman will place the order in a basket or tray for the robot to deliver it.
+		\item For transport with an unattached tray, the robot must pick up the objects and place them on a tray, pick up the tray, and then place the objects from the tray on the table (first placing the tray on the table is allowed).
+		\item If requested, the barman will place the order in a basket or tray for the robot to deliver it.
 		\item Upon arrival to the restaurant, only the team leader is allowed next to the robot for watching and charging.
 		\item If a person from the audience (severely) interferes with the robot in a way that makes it impossible to solve the task, the teams may repeat the test immediately.
 		\item Each Deus Ex Machina penalty for skipping manipulation will only be applied twice per order so receiving an order with three objects is not more punishing.

--- a/tasks/Restaurant.tex
+++ b/tasks/Restaurant.tex
@@ -77,11 +77,12 @@ This task focuses on
 		\item If a person from the audience (severely) interferes with the robot in a way that makes it impossible to solve the task, the teams may repeat the test immediately.
 		\item Each Deus Ex Machina penalty for skipping manipulation will only be applied twice per order so receiving an order with three objects is not more punishing.
 		\item If the robot detects a customer but does not reach their table, the robot must clearly show who was detected to receive points, i.e. displaying a picture of the person.
+		\item When a team is at the front of the queue, they are allowed to start their mapping procedure (the robot must remain in place). When it is their turn, they must bring the robot directly and in a straight line from the front of the queue to the start location. Once at the start location only slight movements are allowed (no moving back and forth, no full rotations etc.)
 	\end{itemize}
 	\item \textbf{Disqualification:}
 	\begin{itemize}
 		\item Touching the robot after the start signal.
-		\item Tweaking, coding, debugging, or mapping the area in place.
+		\item Mapping the area in advance.
 	\end{itemize}
 \end{itemize}
 


### PR DESCRIPTION
- Adjusted DEM penalties to fit scoring item Serve the order
- Clarify usage of unattached trays
- Clarified mapping procedure (Note: I think allowing teams to start their mapping component at the front of the queue is good because I want to save as much time as possible at the start)
- Tweaking/coding before the test to fit test setup is always forbidden, removed here for clarification.