### PR TITLE
German Open Feedback for Stickler for the Rules

### DIFF
--- a/scoresheets/SticklerForRules.tex
+++ b/scoresheets/SticklerForRules.tex
@@ -9,7 +9,7 @@
 \begin{scorelist}
 
 	\scoreheading{Regular Rewards}	
-	\scoreitem[4]{100}{Identify a guest breaking a house rule (indicating the rule by voice or log).}
+	\scoreitem[4]{100}{Identify a guest breaking a house rule (indicating the rule by voice).}
 	\scoreitem[4]{100}{Making eye-contact, politely clarify to the guest what action he should take.}
 	\scoreitem[4]{200}{Confirm that the guest is following the rule.}
 

--- a/tasks/SticklerForRules.tex
+++ b/tasks/SticklerForRules.tex
@@ -69,6 +69,9 @@ This task focuses on
 		\textbf{Policy:} All guests must have a drink in hand at all times.\\
 		\textbf{Action:} Take the guests to the kitchen/bar and make sure they grab a drink.
 	\end{enumerate}
+	\item \textbf{Talking to no one:} If the robot is talking to the empty arena or a wall, no additional penalty is applied. 
+	\item \textbf{Number of Rulebreakers:} Each rule is being broken 0-2 times. There are at least 3 different kind of rules being broken in the arena.
+	\item \textbf{Confirm the Following of a Rule:} When given instructions the guests might not immediately follow them. The robot needs to re-check and confirm that the rule is not being broken anymore. Once the robot has confirmed this it can be assumed that the person is no longer breaking rules.
 \end{itemize}
 
 \subsection*{Instructions:}


### PR DESCRIPTION
- Showing logs afterwards is not sufficient. Robot needs to communicate during test
- Added decision from Bordeaux that a robot talking to no one in the arena about the rule does not incur an additional penalty.
- Added ranges for the number of rulebreakers. These are usually decided on and applied on site in the TLM so why not just have them in the rules
- Added clarification on how confirming a rule being followed works