### PR TITLE
Fix DEM Penalties in Serve Breakfast

### DIFF
--- a/scoresheets/ServeBreakfast.tex
+++ b/scoresheets/ServeBreakfast.tex
@@ -19,9 +19,9 @@ The maximum time for this test is 5 minutes.
 
 	\scoreheading{Deus Ex Machina Penalties}
 	\penaltyitem[4]{5}{Pointing at an object}
-	\penaltyitem[4]{20}{Handing an object over to the robot}
-	\penaltyitem[4]{60}{A human placing an object on the table}
-	\penaltyitem{100}{A human pouring cereal in the bowl}
+	\penaltyitem[4]{50}{Handing an object over to the robot}
+	\penaltyitem[4]{50}{A human placing an object on the table}
+	\penaltyitem{300}{A human pouring cereal in the bowl}
 
 	%\setTotalScore{1000}
 \end{scorelist}


### PR DESCRIPTION
This fixes the DEM penalties in Serve Breakfast to correctly match scoring items.