### PR TITLE
Fix scoresheets document

### DIFF
--- a/documents/scoresheets.tex
+++ b/documents/scoresheets.tex
@@ -109,21 +109,6 @@
 \input{scoresheets/CarryMyLuggage}
 \end{scoresheet}
 
-\renewcommand{\currentTest}{Clean Up}
-\begin{scoresheet}
-\input{scoresheets/CleanUp}
-\end{scoresheet}
-
-\renewcommand{\currentTest}{Farewell}
-\begin{scoresheet}
-\input{scoresheets/Farewell}
-\end{scoresheet}
-
-\renewcommand{\currentTest}{Find my Mates}
-\begin{scoresheet}
-\input{scoresheets/FindMyMates}
-\end{scoresheet}
-
 \renewcommand{\currentTest}{General Purpose Service Robot}
 \begin{scoresheet}
 \input{scoresheets/GPSR}
@@ -132,11 +117,6 @@
 \renewcommand{\currentTest}{Receptionist}
 \begin{scoresheet}
 \input{scoresheets/Receptionist}
-\end{scoresheet}
-
-\renewcommand{\currentTest}{Serving Drinks}
-\begin{scoresheet}
-\input{scoresheets/ServingDrinks}
 \end{scoresheet}
 
 \renewcommand{\currentTest}{Serve the Breakfast}
@@ -149,12 +129,6 @@
 \input{scoresheets/StoringGroceries}
 \end{scoresheet}
 
-\renewcommand{\currentTest}{Take out Garbage}
-\begin{scoresheet}
-\input{scoresheets/TakeOutGarbage}
-\end{scoresheet}
-
-
 % %%% STAGE II %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%% STAGE 2 TESTS GO HERE %%%
@@ -164,25 +138,9 @@
 \input{scoresheets/CleanTable.tex}
 \end{scoresheet}
 
-% EGPSR
 \renewcommand{\currentTest}{Enhanced General Purpose Service Robot}
 \begin{scoresheet}
 \input{scoresheets/EGPSR.tex}
-\end{scoresheet}
-
-\renewcommand{\currentTest}{Find my Disk}
-\begin{scoresheet}
-\input{scoresheets/FindMyDisk.tex}
-\end{scoresheet}
-
-\renewcommand{\currentTest}{Hand me That}
-\begin{scoresheet}
-\input{scoresheets/HandMeThat.tex}
-\end{scoresheet}
-
-\renewcommand{\currentTest}{Set the Table}
-\begin{scoresheet}
-\input{scoresheets/SetTable.tex}
 \end{scoresheet}
 
 \renewcommand{\currentTest}{Restaurant}
@@ -190,19 +148,9 @@
 \input{scoresheets/Restaurant.tex}
 \end{scoresheet}
 
-\renewcommand{\currentTest}{Smoothie Chef}
-\begin{scoresheet}
-\input{scoresheets/SmoothieChef.tex}
-\end{scoresheet}
-
 \renewcommand{\currentTest}{Stickler for Rules}
 \begin{scoresheet}
 \input{scoresheets/SticklerForRules.tex}
-\end{scoresheet}
-
-\renewcommand{\currentTest}{Where is this}
-\begin{scoresheet}
-\input{scoresheets/WhereIsThis.tex}
 \end{scoresheet}
 
 % %%% FINALS   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/setup/macros_scoresheets.tex
+++ b/setup/macros_scoresheets.tex
@@ -573,12 +573,12 @@
 	}{}%
 
 	% outstanding performance bonus %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%	\ifthenelse{%
-%		\value{currOutstandingBonus}>0 \AND %
-%		\equal{\scorelistOutstanding}{true}%
-%	}{%
-%		\bonusitem{\thecurrOutstandingBonus}{Outstanding performance~\ifShortScoresheet{(see sec.~\ref{rule:outstanding_performance})}{}}%
-%	}{}%
+	\ifthenelse{%
+		\value{currOutstandingBonus}>0 \AND %
+		\equal{\scorelistOutstanding}{true}%
+	}{%
+		\bonusitem{\thecurrOutstandingBonus}{Outstanding performance~\ifShortScoresheet{(see sec.~\ref{rule:outstanding_performance})}{}}%
+	}{}%
 	%
 	% Total score %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	\\[-1em]\hline


### PR DESCRIPTION
This commit:

- removes unused scoresheets from the scoresheet document
- adds bonus item for outstanding performance

Removed unused tests from the scoresheet document but this does not delete the files as there also are unused test descriptions and everything shall be removed in another cleanup commit.

The bonus was already included in the `total scores` line and, as outstanding performance is still in the rulebook, i just re-enabled the line to be listed under bonuses.

