### PR TITLE
Portugal Open Feedback for Storing Groceries

### DIFF
--- a/scoresheets/StoringGroceries.tex
+++ b/scoresheets/StoringGroceries.tex
@@ -17,9 +17,6 @@ The maximum time for this test is 5 minutes.
 	\scoreitem{70}{Picking up a heavy object}
 	\scoreitem{30}{Placing a heavy object}
 
-	\scoreheading{Penalties}
-	\penaltyitem[5]{-60}{Storing an object without categorizing it correctly}
-
 	\scoreheading{Deus Ex Machina Penalties}
 	\penaltyitem[5]{-50}{A human handing an object over to the robot}
 	\penaltyitem[5]{-15}{A human placing an object in the cabinet}

--- a/tasks/StoringGroceries.tex
+++ b/tasks/StoringGroceries.tex
@@ -73,9 +73,10 @@ The robot stores groceries into a cabinet with shelves. Objects are sorted on th
 	\end{itemize}
 	\item \textbf{Communicating Perception}: The robot must clearly communicate its perception to the referee.
 	Pointing at the object or attempting to pick it up is sufficent. When using visualization, make sure the robot 
-	tells the referee where to look and and make the visualization easily accesible. 
+	tells the referee where to look and make the visualization easily accesible. 
 	If the team wants to utilize bounding boxes make sure \textbf{only} one object with a bounding box is shown 
-	at a time so the referee is easily able to check and verify.
+	at a time so the referee is easily able to check and verify. Also make sure the surrounding scene is visible, i.e.
+	just showing a cropped bounding box is not enough.
 \end{enumerate}
 
 \subsection*{OC Instructions}


### PR DESCRIPTION
- Removed unnecessary penalty
- Add clarification to visualization. Surrounding scene must be visible. Just cropped bounding box not enough
- Fixed typo