### PR TITLE
added subsection for alternative start signal

### DIFF
--- a/pages/general_rules/Procedure.tex
+++ b/pages/general_rules/Procedure.tex
@@ -91,32 +91,41 @@ Robots not obeying the rules are stopped and removed from the \Arena{}.
 \end{enumerate}
 
 
-\subsection{Start signal}\label{rule:start_signal}
+\subsection{Start Signal}\label{rule:start_signal}
 The default \iterm{start signal} (unless stated otherwise) is \iterm{door opening}.
 Other start signals are allowed but must be authorized by the \iaterm{Technical Committee}{TC} during the Robot Inspection (see~\refsec{sec:robot_inspection}).
 
 \begin{enumerate}
-	\item \textbf{Door opening:} The robot is waiting behind the door, outside the \Arena{} and accompanied by a team member.
-	The test starts when a referee (not a team member) opens the door.
+    \item \textbf{Door opening:} The robot is waiting behind the door, outside the \Arena{} and accompanied by a team member.
+    The test starts when a referee (not a team member) opens the door.
 
-	\item \textbf{Start button:} If the robot is not able to automatically start after the door is open, the team may start the robot using a start button.
-	\begin{enumerate}[nosep]
-		\item It must be a physical button on the robot (e.g., a dedicated one or releasing the eStop).
-		\item It is allowed to use the robot's contact/pressure sensors (e.g., pushing the head or an arm joint).
-		\item Using a start button needs to be announced to the referees before the test starts.
-		\item There may be penalties for using a start button in some tests
-	\end{enumerate}
+    \item \textbf{Start button:} If the robot is not able to automatically start after the door is open, the team may start the robot using a start button.
+    \begin{enumerate}[nosep]
+        \item It must be a physical button on the robot (e.g., a dedicated one or releasing the eStop).
+        \item It is allowed to use the robot's contact/pressure sensors (e.g., pushing the head or an arm joint).
+        \item Using a start button needs to be announced to the referees before the test starts.
+        \item There may be penalties for using a start button in some tests.
+    \end{enumerate}
 
-	\item \textbf{Ad-hoc start signal:} Other means of triggering robot to action are allowed but must be approved by the \iaterm{Technical Committee}{TC} during the Robot Inspection (see~\refsec{sec:robot_inspection}).
-	These include:
-	\begin{itemize}[nosep]
-		\item QR Codes
-		\item Verbal instructions
-		\item Custom HRI interfaces (apps, software, etc.)
-	\end{itemize}
-	\textbf{Remark:} There may be penalties for using Ad-hoc start signals in some tests. The use of mouses, keyboards, and devices attached to ECRA computers is strictly forbidden.
+    \item \textbf{Ad-hoc start signal:} Other means of triggering the robot to action are allowed but must be approved by the \iaterm{Technical Committee}{TC} during the Robot Inspection (see~\refsec{sec:robot_inspection}).
+    These include:
+    \begin{itemize}[nosep]
+        \item QR Codes
+        \item Verbal instructions
+        \item Custom HRI interfaces (apps, software, etc.)
+    \end{itemize}
+    \textbf{Remark:} There may be penalties for using Ad-hoc start signals in some tests. The use of mouses, keyboards, and devices attached to ECRA computers is strictly forbidden.
 
+    \item \textbf{No penalties for physical constraints (HSR only):} 
+    In cases where a physical issue, such as a door bump, impedes the league's ability to ensure a standard start signal with full safety for the HSR robot, penalties will not be imposed. The following guidelines apply:
+    \begin{itemize}[nosep]
+        \item The team must document the physical issue and notify the committee prior to the Robot Inspection.
+        \item The issue must be reviewed and approved by the league's rules committee.
+        \item An alternative start method will be determined on-site in consultation with the committee.
+    \end{itemize}
+    This rule ensures fairness and flexibility while addressing unavoidable physical challenges during league operations.
 \end{enumerate}
+
 
 
 \subsection{Entering and leaving the \Arena{}}


### PR DESCRIPTION
### Added Subsection for Alternative Start Signal

#### Description

This pull request addresses [Issue #890](https://github.com/RoboCupAtHome/RuleBook/issues/890).

**Proposed changes:**
- Clarifies scenarios in which teams may request an alternative start signal.
- Defines the procedure for handling such requests.