### PR TITLE
allowing hsr microphone

### DIFF
--- a/pages/general_rules/ExternalDevices.tex
+++ b/pages/general_rules/ExternalDevices.tex
@@ -31,6 +31,18 @@ Interacting with anything in the ECRA after the referee has given the start sign
 
 If a laptop is used as \ExternalComputing, a team can only place it in the ECRA if their \Testslot{} is up next and must remove the device immediately after the test.
 
+
+\subsection{Microphones for HSR}
+\label{rule:microphones_hsr}
+
+To address the inherent challenges in the auditory systems of the Toyota HSR, the use of external microphones is allowed under the following conditions:
+\begin{itemize}
+    \item \textbf{Connection:} External microphones may be connected to the HSR via USB or AUX.
+    \item \textbf{Mounting:} The microphone can only be mounted directly on the robot.
+    \item \textbf{Wireless Microphones:} Wireless microphones are NOT allowed.
+    \item \textbf{Built-in Microphone Usage:} Teams may choose to use only the built-in HSR microphone.
+\end{itemize}
+
 \subsection{On-line external computing}
 \label{rule:robot_external_computing_online}
 


### PR DESCRIPTION
## A new subsection to the External Devices section that formalizes the use of external microphones on the Toyota HSR has been added.

Specifies the conditions under which external microphones can be used, including USB/AUX connections, wireless options, and the use of the built-in microphone.
Closes issue # [888](https://github.com/RoboCupAtHome/RuleBook/issues/888)

