### PR TITLE
added microphone for hsr

### DIFF
--- a/pages/general_rules/Robots-SPL.tex
+++ b/pages/general_rules/Robots-SPL.tex
@@ -16,6 +16,7 @@ Any laptop fitting inside the \MountingBracket{} is allowed to be used, regardle
 Furthermore, teams are allowed to attach the following devices to either the \HSR{} or the laptop in the \MountingBracket:
 \begin{itemize}
 	\item \textbf{Audio}: A USB audio output device, such as a USB speaker or a sound card dongle.
+	    \item \textbf{Microphone}: A USB or AUX external microphone. Wireless microphones are not allowed.
 	\item \textbf{Wi-Fi adapter}: A USB-powered IEEE 802.11ac (or newer) compliant device.
 	\item \textbf{Ethernet Switch}: A USB-powered IEEE 802.3ab (or newer) compliant device.
 \end{itemize}


### PR DESCRIPTION
## A new subsection to the External Devices section that formalizes the use of external microphones on the Toyota HSR has been added.

Specifies the conditions under which external microphones can be used, including USB/AUX connections, wireless options, and the use of the built-in microphone.
Closes issue # [888](https://github.com/RoboCupAtHome/RuleBook/issues/888)