### PR TITLE
Updates clean table 2025

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ BUILD_DIR:=$(ROOT_DIR)/.build
 SILENT = @
 MSG      = echo
 HASRUBBER:=$(shell which rubber)
+XELATEX:=$(shell which xelatex)
 
 ## COLORS 
 RESET       = tput sgr0
@@ -51,6 +52,9 @@ ifdef HASRUBBER
 	$(SILENT) rubber --unsafe --pdf --force $$<
 else
 	$(SILENT) latexmk -Werror -shell-escape -silent -pdf -interaction=nonstopmode -outdir=$${BUILD_DIR} $$<
+endif
+ifdef XELATEX
+	$(SILENT) xelatex $$<
 endif
 
 ## Generate Summary Rule

--- a/scoresheets/CleanTable.tex
+++ b/scoresheets/CleanTable.tex
@@ -1,11 +1,12 @@
 \begin{scorelist}[timelimit=10]
 	\scoreheading{Main Goal}
 	\scoreitem{15}{Navigate to the table to pick up items}
-	\scoreitem[2]{40}{Picking tableware (cup, bowl) for transportation to the dishwasher}
-	\scoreitem{50}{Picking up a plate for transportation to the dishwasher}
+	\scoreitem[3]{50}{Picking tableware (cup, bowl, plate) for transportation to the dishwasher}
 	\scoreitem[2]{80}{Picking up cutlery (spoon, fork) for transportation to the dishwasher}
+	\scoreitem[2]{50}{Picking up a drink for transportation to the trash bin}
 	\scoreitem[5]{50}{Placing the tableware and cutlery inside the dishwasher}
-	\scoreitem[5]{50}{Placing an item correctly (cleanable, convenient like a human would) in the dishwasher}
+	\scoreitem[5]{75}{Placing an item correctly (cleanable, convenient like a human would) in the dishwasher}
+	\scoreitem[2]{50}{Placing a drink inside the trash bin}
 
 	\scoreheading{Bonus Rewards}
 	\scoreitem{100}{Pulling out the dishwasher rack}
@@ -14,12 +15,15 @@
 	\scoreitem{200}{Closing the dishwasher door}
 	\scoreitem{100}{Picking up the dishwasher tab for transportation to the dishwasher}
 	\scoreitem{200}{Placing the dishwasher tab inside the dishwasher's hatch intended for the tab}
+	\scoreitem[2]{50}{Wiping the area where the drink was}
 
 	\scoreheading{Deus Ex Machina Penalties}
-	\penaltyitem[2]{40}{Handing tableware over to the robot}
-	\penaltyitem{50}{Handing plate over to the robot}
+	\penaltyitem[3]{50}{Handing tableware over to the robot}
 	\penaltyitem[2]{80}{Handing cutlery over to the robot}
+	\penaltyitem[2]{50}{Handing a drink over to the robot}
 	\penaltyitem[5]{50}{Having a human place an object in the dishwasher}
+	\penaltyitem[2]{50}{Having a human place a drink inside the trash bin}
+	\penaltyitem[2]{25}{A human pointing at the trash bin}
 	%\setTotalScore{1000}
 \end{scorelist}
 

--- a/tasks/CleanTable.tex
+++ b/tasks/CleanTable.tex
@@ -1,15 +1,15 @@
 \section{Clean the Table}
 \label{test:clean-the-table}
-The robot has to remove all dishes and cutlery from a table and place them into the dishwasher.\\
+The robot cleans up a table after a meal. All dishes and cutlery must be placed inside the dishwasher and drinks must be placed inside the trash. \\
 
-\noindent \textbf{Main goals:} All tableware and cutlery on the table is placed inside the dishwasher (five objects in total).\\
+\noindent \textbf{Main goals:}  Clean up all the objects on the table. Tableware and cutlery have to be placed correctly inside the dishwasher and drinks must be placed inside the trash bin. \\
 
 \noindent \textbf{Optional goals:}
 \begin{enumerate}[nosep]
 	\item Opening the dishwasher door
 	\item Pulling out the dishwasher rack
-	\item Placing the items in the dishwasher correctly
 	\item Placing a dishwasher tab inside the dishwasher
+	\item Wipe the table area where the drink was
 \end{enumerate}
 
 \subsection*{Focus}
@@ -22,6 +22,7 @@ The robot has to remove all dishes and cutlery from a table and place them into 
 \begin{itemize}[nosep]
 	\item \textbf{Locations:}
 		\begin{itemize}
+			\item \textbf{Start Location:} Before the test, the robot waits outside the Arena and navigates to the testing area when the door is open.
 			\item \textbf{Test location:} This test takes place in the kitchen.
 		\end{itemize}
 	\item \textbf{People:}
@@ -30,18 +31,21 @@ The robot has to remove all dishes and cutlery from a table and place them into 
 		\end{itemize}
 	\item \textbf{Furniture:}
 		\begin{itemize}
-			\item \textbf{Dining table:} A dining table is located close to the dishwasher.
+			\item \textbf{Dishwasher:} A dishwasher is located close to the dining table.
 			\item \textbf{Tray:} A plastic tray, which may have other tableware and cutlery placed inside, is located either on top of the dishwasher or on one of the racks. Objects can be placed either in the dishwasher rack or in the tray, based on the team's choice.
+			\item \textbf{Trash bin:} A trash bin is located in the kitchen.
 		\end{itemize}
 	\item \textbf{Objects:}
 		\begin{itemize}
-			\item \textbf{Table setting:} The table has a total of five objects disposed in a typical setting for a meal for one person.
+			\item \textbf{Table setting:} The table has a total of seven objects disposed in a typical setting for a meal for one person.
 			The object distribution is as follows:
 			\begin{itemize}[nosep]
-				\item\textit{Silverware}: Any two objects (fork, knife, or spoon).
-				\item\textit{Tableware}: Any three objects (except silverware), at least one of which is a dish.
+				\item\textit{Cutlery}: Any two objects (fork, knife, or spoon).
+				\item\textit{Tableware}: Any three objects (except cutlery), at least one of which is a dish.
+				\item\textit{Drinks}: Any two drinks from the object set.
 			\end{itemize}
-			\item \textbf{Dishwasher tab:} The tab can be found at a location that is announced before the test and should be autonomously placed inside the tab slot in the dishwasher.
+			\item \textbf{Dishwasher tab:} The tab can be found at a location announced before the test and should be autonomously placed inside the tab slot in the dishwasher.
+			\item \textbf{Wiping Object:} The wiping object (i.e. a sponge) can be found at a location announced before the test.
 		\end{itemize}
 \end{itemize}
 
@@ -57,7 +61,7 @@ The robot has to remove all dishes and cutlery from a table and place them into 
 			\item whether the dishwasher door should be closed and, if the door is open, whether the rack should be pushed in
 		\end{itemize}
 	\item \textbf{Test start:} The robot moves to the kitchen when the arena door is open.
-	\item \textbf{Table clean up:} The robot cleans the table by putting all items that are on it in the dishwasher.
+	\item \textbf{Table clean up:} The robot cleans the table by putting: the cutlery and tablware items inside the dishwasher and the drinks in the trash bin.
 \end{enumerate}
 
 
@@ -75,7 +79,15 @@ The robot has to remove all dishes and cutlery from a table and place them into 
 	\begin{itemize}[nosep]
 		\item pointing to an object or telling the robot where an object is
 		\item handing an object over to the robot
+		\item telling or pointing out to the robot where to place an object
+		\item moving an object instead of the robot
 	\end{itemize}
+	\item \textbf{Communicating Perception}: The robot must clearly communicate its perception to the referee.
+	Pointing at the object or attempting to pick it up is sufficent. When using visualization, make sure the robot 
+	tells the referee where to look and make the visualization easily accesible. 
+	If the team wants to utilize bounding boxes make sure \textbf{only} one object with a bounding box is shown 
+	at a time so the referee is easily able to check and verify. Also make sure the surrounding scene is visible, i.e.
+	just showing a cropped bounding box is not enough.
 \end{enumerate}
 
 \subsection*{OC Instructions}
@@ -87,6 +99,8 @@ During the \SetupDays:
 At least two hours before the test:
 \begin{itemize}
 	\item Announce the predefined location of the dishwasher tab.
+	\item Announce what is the object used for wiping.
+	\item Announce the predefined location of the object used for wiping.
 \end{itemize}
 
 
@@ -94,7 +108,7 @@ At least two hours before the test:
 
 The referee needs to:
 \begin{itemize}
-	\item Place objects on the table.
+	\item Place objects on the table (two pieces of cutlery, three pieces of tableware and two drinks)
 	\item Place the plastic tray on the dishwasher or on a rack, as requested by the team.
 \end{itemize}
 

--- a/tasks/CleanTable.tex
+++ b/tasks/CleanTable.tex
@@ -37,7 +37,7 @@ The robot cleans up a table after a meal. All dishes and cutlery must be placed 
 		\end{itemize}
 	\item \textbf{Objects:}
 		\begin{itemize}
-			\item \textbf{Table setting:} The table has a total of seven objects disposed in a typical setting for a meal for one person.
+			\item \textbf{Table setting:} The table has a total of seven objects disposed in a typical setting for a meal for one person. The cutlery and tableware objects may be randomly stacked as it is common after a meal. 
 			The object distribution is as follows:
 			\begin{itemize}[nosep]
 				\item\textit{Cutlery}: Any two objects (fork, knife, or spoon).
@@ -79,8 +79,6 @@ The robot cleans up a table after a meal. All dishes and cutlery must be placed 
 	\begin{itemize}[nosep]
 		\item pointing to an object or telling the robot where an object is
 		\item handing an object over to the robot
-		\item telling or pointing out to the robot where to place an object
-		\item moving an object instead of the robot
 	\end{itemize}
 	\item \textbf{Communicating Perception}: The robot must clearly communicate its perception to the referee.
 	Pointing at the object or attempting to pick it up is sufficent. When using visualization, make sure the robot 
@@ -95,11 +93,11 @@ The robot cleans up a table after a meal. All dishes and cutlery must be placed 
 During the \SetupDays:
 \begin{itemize}
 	\item Provide official cutlery and tableware for training.
+	\item Announce what is the object used for wiping.
 \end{itemize}
 At least two hours before the test:
 \begin{itemize}
 	\item Announce the predefined location of the dishwasher tab.
-	\item Announce what is the object used for wiping.
 	\item Announce the predefined location of the object used for wiping.
 \end{itemize}
 


### PR DESCRIPTION
## Description

As discussed in the TC meeting (06/01/2025) here are again the updates to the clean the table, hopefully this PR doesn't get closed instead of being edited...

Added two drinks to the table to be placed inside the trash bin. Creating a much more realistic scenario, where there is tableware and cutlery to be placed inside the dishwasher and drinks inside the trash bin (in the previous version there were also foods to be restored in the cabinet which were removed since Storing Groceries will remain in stage 1).
 
 Proposed changes:
 	
 	- Added "Wipe the table area where the drink was" to optional goals 
 	- Added two drinks will be on the table that must be placed inside the trash bin
 	- Added wiping object (i.e. sponge) must be placed somewhere near (by the referee) for wiping, ideally next to dishwasher tab
 	- Moved "Placing the items in the dishwasher correctly" from optional goals to main goals (already was in the main goals in the scoresheet, must have been forgotten in a previous update)
 	
 	- Standardized picking plate bowl and cup, there was a 10 point difference between them (dont think a 10 points makes a difference, this way is standardized, and is less bullet points in scoring and in DEM, not as confusing for refs)
 	- Added picking and placing the drinks scores to scoresheet
 	- Added DEM to picking and placing drinks 
 	- Increased points for placing objects correctly in a dishwasher as a human would by 25 (this should be the main focus of the task...)
 	
 