### PR TITLE
Higher number of problems for egpsr

### DIFF
--- a/scoresheets/EGPSR.tex
+++ b/scoresheets/EGPSR.tex
@@ -1,15 +1,31 @@
 \begin{scorelist}[timelimit=10]
-	\scoreheading{Main Goal}
+	\scoreheading{Main Goal (can be repeated unlimited times)}
 	\scoreitem[3]{150}{Find and clearly state an encountered problem}
 	\scoreitem[3]{650}{Solve a problem}
 
+	\scoreheading{Penalties}
+	\penaltyitem[1]{100}{Find repeated problem category}
+	\penaltyitem[1]{300}{Solving repeated problem category for the 2nd time}
+	\penaltyitem[1]{500}{Solving repeated problem category for the 3rd (or more) time}
 
 	\scoreheading{Deus Ex Machina Penalties}
 	\penaltyitem[3]{150}{Asking for location of a problem}
-	\penaltyitem[3]{650}{Instructing a human to perform parts of the task will apply a percentage penalty according to similar penalties in other Stage II tests.}
+	\penaltyitem[3]{650}{
+		Instructing a human to perform parts of the task will apply a \\
+		percentage penalty according to similar penalties in other \\
+		Stage II tests.
+		}
+
 \end{scorelist}
+
+\ifShortScoresheet{}{
+	\textbf{Referee Information:}
+	Note each problem (category, item, location) and mark if they are stated by the robot in remarks
+}%
+	
 
 
 % Local Variables:
 % TeX-master: "Rulebook"
 % End:
+

--- a/setup/macros_scoresheets.tex
+++ b/setup/macros_scoresheets.tex
@@ -59,7 +59,7 @@
 \newcommand{\firstTryColumnCaption}{First try}
 
 % Sets the second column's name for referee scoring when \attempts=2
-\newcommand{\secondTryColumnCaption}{Restart}
+\newcommand{\secondTryColumnCaption}{Second try}
 
 % Sets the name of the column for referee scoring when \attempts=1
 \newcommand{\firstColumnCaption}{Action}

--- a/tasks/EGPSR.tex
+++ b/tasks/EGPSR.tex
@@ -1,9 +1,8 @@
-\section{Enhanced General Purpose Service Robot}
-\label{test:egpsr}
+\section{Enhanced General Purpose Service Robot}\label{test:egpsr}
 The robot is asked to maintain the household by cleaning up the arena and assisting people.
 
 
-\noindent \textbf{Main Goal:} Solve 3 problems in the arena.\\
+\noindent \textbf{Main Goal:} Solve different problems in the arena.\\
 
 
 \subsection*{Focus}
@@ -18,7 +17,8 @@ The arena is in its default state apart from problems set up for the robot to so
 \begin{enumerate}
     \item \textbf{Problems:}
 		\begin{itemize}
-			\item \textbf{Objects:} Objects that are not in their default location should be returned there (see \ref{rule:scenario_objects}). Objects on the floor are to be thrown in the trash or returned to their default location.
+			\item \textbf{Trash:} Objects on the floor are to be thrown in the trash.
+			\item \textbf{Objects:} Objects that are not in their default location should be returned there (see~\ref{rule:scenario_objects}). 
 			\item \textbf{Persons:} Some persons in the arena will have requests for the robot. They will raise their hand if the robot is in the same room.
 		\end{itemize}
 \end{enumerate}
@@ -39,10 +39,12 @@ The arena is in its default state apart from problems set up for the robot to so
 % %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection*{Additional rules and remarks}
 \begin{enumerate}[nosep]
+	\item \textbf{Number of Problems:} The number of problems depends on the arena size the minimum count of generated problems is 8.
+	\item \textbf{Repeating Problem Category:} Solving the same Category of Problem incurs a penalty. 
+	\item \textbf{Solving more:} You can continue solving problems to compensate for penalties.
 	\item \textbf{Partial Scoring:} The main task allows partial scoring (per \emph{solved} problem).
-
 	\item \textbf{Command Generator:} Problems and commands will be generated using the official command generator\footnote{\url{https://github.com/johaq/CommandGenerator}}.
-	\item \textbf{Finding People:} Finding a person and stating they need help is enough to get the scoring item. 
+	\item \textbf{Finding People:} Finding a person and stating they need help counts as finding the problem.
 	\item \textbf{Understanding Commands:} Understanding and correctly repeating the command given by a person can be counted towards partially solving a problem.
 \end{enumerate}
 


### PR DESCRIPTION
## Description

EGPSR is boring for the audience as most of the time is spend searching for problems. This tries to deal with that by increasing the number of problems (depending on the arena size). 
To encourage solving different categories of problems (e.g. finding 3x trash is boring) solving the same category of problem now incurs a penalty which can be compensated by solving more problems.

Examples for reaching maximum score :
- (3 problems): Find and solve 3 different problem categories 
- (4 problems): Find and solve 2 different problem categories twice
- (5 problems): Find and solve 1 category once and another 4 times
- (5 problems): Find and solve 1 category 5 times and continue to find 8 additional problems of the other categories


Changes proposed in this pull request:
* state the minimum number of generated problems is 8.
* solving the same Category of Problem incurs a penalty. 
* no limit on the number of solved problems

## Other comments
The scoresheet is rough. Maybe this should be more like table for referees to note down the problems and penalties or something.

Command Generator has to modified and moved to this namespace. 