### PR TITLE
Add recommended door width fixes #945

### DIFF
--- a/pages/general_rules/Scenario.tex
+++ b/pages/general_rules/Scenario.tex
@@ -27,7 +27,7 @@ The indoor home setting will be surrounded by high and low \Term{walls}{Arena wa
 
 \begin{enumerate}
 	\item \textbf{Walls:} Walls are fixed and cannot be modified during the competition. The minimum wall height is \SI{60}{\centi\meter}; a maximum height is not specified, but must allow the audience to watch the competition.
-	\item \textbf{Doors:} Inside the \Arena{}, rooms are connected by doors (at least one). All doors have handles, not knobs, and can be closed at any time; it is thus expected that robots are either able to open them or find a plan around them. All doors must meet minimum accessibility requirements but they should try to meet the minimum accessibility width of \SI{915}{\milli\meter}.
+	\item \textbf{Doors:} Inside the \Arena{}, rooms are connected by doors (at least one). All doors have handles, not knobs, and can be closed at any time; it is thus expected that robots are either able to open them or find a plan around them. All doors must meet minimum accessibility requirements but they should try to meet the recommended accessibility width of \SI{915}{\milli\meter}.
 	\item \textbf{Floor:} The floor and doorways of the \Arena{} are even, so there are no significant steps or stairways; however, minor unevenness, such as carpets, transitions in floor covering between different areas, and minor gaps (especially at doorways) can be expected.
 	\item \textbf{Appearance:} The floor and walls are mostly monochromatic, but may contain textures, such as a carpet on the floor, or a poster or picture on the wall.
 \end{enumerate}

--- a/pages/general_rules/Scenario.tex
+++ b/pages/general_rules/Scenario.tex
@@ -27,7 +27,7 @@ The indoor home setting will be surrounded by high and low \Term{walls}{Arena wa
 
 \begin{enumerate}
 	\item \textbf{Walls:} Walls are fixed and cannot be modified during the competition. The minimum wall height is \SI{60}{\centi\meter}; a maximum height is not specified, but must allow the audience to watch the competition.
-	\item \textbf{Doors:} Inside the \Arena{}, rooms are connected by doors (at least one). All doors have handles, not knobs, and can be closed at any time; it is thus expected that robots are either able to open them or find a plan around them.
+	\item \textbf{Doors:} Inside the \Arena{}, rooms are connected by doors (at least one). All doors have handles, not knobs, and can be closed at any time; it is thus expected that robots are either able to open them or find a plan around them. All doors must meet minimum accessibility requirements but they should try to meet the minimum accessibility width of \SI{915}{\milli\meter}.
 	\item \textbf{Floor:} The floor and doorways of the \Arena{} are even, so there are no significant steps or stairways; however, minor unevenness, such as carpets, transitions in floor covering between different areas, and minor gaps (especially at doorways) can be expected.
 	\item \textbf{Appearance:} The floor and walls are mostly monochromatic, but may contain textures, such as a carpet on the floor, or a poster or picture on the wall.
 \end{enumerate}


### PR DESCRIPTION

This adds a new requirement that doors must meet minimum standards for accessibility reasons and that they should try to meet the recommended width of 915mm for accessibility reasons.

As each country has slightly different minimum standards and recommended standards I left the wording vague, and only listed the recommended number.

When Local Organizing Committees scan the rule book or when we pass on the requirements to the local venues it is better to ask for 915mm and see how close we get.

In the OPL league subsection it still recommends robots no wider than 70cm to ensure robots fit through doors.

Closes issue #945
