### PR TITLE
[GO feedback] SG: reduce point for opening the second cabinet door

### DIFF
--- a/scoresheets/StoringGroceries.tex
+++ b/scoresheets/StoringGroceries.tex
@@ -6,8 +6,8 @@
 	\scoreitem[5]{15}{Perceiving objects in shelf and saying on which layer the currently handled object should be placed}
 	\scoreitem[5]{15}{Placing an object in the cabinet}
 	\scoreitem[5]{50}{Placing an object next to similar objects on the cabinet}
-	\scoreitem[1]{200}{Opening the first cabinet door }
-	\scoreitem[1]{100}{Opening the second cabinet door }
+	\scoreitem[1]{200}{Opening the first cabinet door}
+	\scoreitem[1]{100}{Opening the second cabinet door}
 	\scoreitem{300}{Pouring cereal into the container}
 
 	\scoreheading{Bonus Rewards}

--- a/scoresheets/StoringGroceries.tex
+++ b/scoresheets/StoringGroceries.tex
@@ -6,7 +6,8 @@
 	\scoreitem[5]{15}{Perceiving objects in shelf and saying on which layer the currently handled object should be placed}
 	\scoreitem[5]{15}{Placing an object in the cabinet}
 	\scoreitem[5]{50}{Placing an object next to similar objects on the cabinet}
-	\scoreitem[2]{100}{Opening a cabinet door }
+	\scoreitem[1]{200}{Opening the first cabinet door }
+	\scoreitem[1]{100}{Opening the second cabinet door }
 	\scoreitem{300}{Pouring cereal into the container}
 
 	\scoreheading{Bonus Rewards}


### PR DESCRIPTION
## Description

During the German open FAQ teams we specified that asking the referee to open one door still enables the robot to score opening the second door. As the first door is much harder to open (need to use handle or rims ) than the second (possible grasp behind) It should reward a different number of points.
