### PR TITLE
(CI) use newer lint action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: LaTeX linter (chktex)
-        uses: j2kun/chktex-action@v2.0.0
+        uses: j2kun/chktex-action@v2.1.0
         # Provide this output for context, but don't fail builds
         continue-on-error: true
         env:


### PR DESCRIPTION
Current one fails to run, but this doesn't show because of settings

The new action allows for checking only updated files in a PR. When we would do that, we could remove the `continue-on-error`. And enforce the linting on updated files. Which would slowly increase the linting on the entire rulebook.