### PR TITLE
Allow custom tasks during finals

### DIFF
--- a/scoresheets/Finals.tex
+++ b/scoresheets/Finals.tex
@@ -5,6 +5,9 @@
 	\scoreitem[1]{600}{Opening the Door of the Apartment}
 	\scoreitem[1]{600}{Closing the Dishwasher}
 	\scoreitem[1]{300}{Closing a Cabinet Door}
+	\scoreitem[1]{0}{Custom Task}
+	\scoreitem[1]{0}{Custom Task}
+	\scoreitem[1]{0}{Custom Task}
 
 	\scoreheading{Penalties}
 	\penaltyitem[1]{100}{Find repeated EGPSR problem category}

--- a/tasks/Finals.tex
+++ b/tasks/Finals.tex
@@ -34,7 +34,7 @@ The procedure for the demonstration is the same as for Enhanced General Purpose 
 \item \textbf{Team-Supplied Items} In the event that additional items are necessary for the completion of a task (e.g., clothing for folding, watering cans), the requesting team is responsible for supplying these items.
 \begin{enumerate}[nosep]
   \item \textbf{Standardization} These items must be regular household items (no markers, no custom printed handles etc.).
-  \item \textbf{Availability} All requested items must be provided and made available to the competitors prior to the day of the final. At least two identical copies of each item must be supplied to ensure adequate access task.
+  \item \textbf{Availability} All requested items must be provided and made available to the competitors prior to the day of the final. At least two identical copies of each item must be supplied to ensure adequate access.
 \end{enumerate}
 \end{enumerate}
 

--- a/tasks/Finals.tex
+++ b/tasks/Finals.tex
@@ -22,6 +22,16 @@ The procedure for the demonstration is the same as for Enhanced General Purpose 
 \begin{enumerate}[nosep]
 \item \textbf{Closing Furniture:} Doors of the Cabinet as well as the Dishwasher need to be closed.
 \item \textbf{Welcome Guest:} There is an additional Person waiting behind the Exit door.
+\item \textbf{Custom Tasks:} Additional reasonable household task.
+\end{enumerate}
+
+\subsubsection{Custom Tasks}
+\begin{enumerate}[nosep]
+\item \textbf{Requesting Additional Tasks:} Additional reasonable household tasks may be requested for scoring during the team leader meetings. These tasks must be approved by the \TC{}.
+
+\item \textbf{Arena-Specific Tasks:} Depending on the arena setup, certain household chores may be delegated to the robot for completion. Examples of tasks that may be handled by the robot include, but are not limited to, window cleaning and picture alignment on the wall.
+
+\item \textbf{Provision of Required Items} In the event that additional items are necessary for the completion of a task (e.g., clothing for folding, watering cans), the requesting team is responsible for supplying these items. All requested items must be provided and made available to the competitors prior to the day of the final.
 \end{enumerate}
 
 \subsection*{Score sheet}

--- a/tasks/Finals.tex
+++ b/tasks/Finals.tex
@@ -31,7 +31,11 @@ The procedure for the demonstration is the same as for Enhanced General Purpose 
 
 \item \textbf{Arena-Specific Tasks:} Depending on the arena setup, certain household chores may be delegated to the robot for completion. Examples of tasks that may be handled by the robot include, but are not limited to, window cleaning and picture alignment on the wall.
 
-\item \textbf{Provision of Required Items} In the event that additional items are necessary for the completion of a task (e.g., clothing for folding, watering cans), the requesting team is responsible for supplying these items. All requested items must be provided and made available to the competitors prior to the day of the final.
+\item \textbf{Team-Supplied Items} In the event that additional items are necessary for the completion of a task (e.g., clothing for folding, watering cans), the requesting team is responsible for supplying these items.
+\begin{enumerate}[nosep]
+  \item \textbf{Standardization} These items must be regular household items (no markers, no custom printed handles etc.).
+  \item \textbf{Availability} All requested items must be provided and made available to the competitors prior to the day of the final. At least two identical copies of each item must be supplied to ensure adequate access task.
+\end{enumerate}
 \end{enumerate}
 
 \subsection*{Score sheet}


### PR DESCRIPTION
** Note: Your contribution is expected to meet the conventions and policies described in the [contribution guidelines](https://github.com/RoboCupAtHome/RuleBook/wiki/Guidelines:-Contributing) **

## Description

Closes issue #952

If Teams are able to show other tasks that they think should be included in egpsr they could bring them up during the Team Leader meetings and the task score will be decided on-site by the TC. Any used Items must be provided to all teams.

Example of useful skills not present in the rulebook:

- Cleaning up the windows.
- Finding and cleaning up a spill on the Table.
- Pouring and delivering a drink.
- Water the plants. (The Team provides some watering cans for the Arena)



