### PR TITLE
Sync Author List Between `about.tex` and `citation.bib`

### DIFF
--- a/citation.bib
+++ b/citation.bib
@@ -1,11 +1,9 @@
-@misc{rulebook_2024,
+@misc{rulebook_2025,
   author =       {Hart, Justin and Moriarty, Alexander and Pasternak, Katarzyna
-                  and Kummert, Johannes and Hawkin, Alina and Hassouna, Vanessa
-                  and Pena Narvaez, Juan Diego and Ruegemer, Leroy
-                  and von Seelstrang, Leander and Van Dooren, Peter 
-                  and Garcia, Juan Jose, and Mitzutani, Akinobu 
-                  and Jiang, Yuqian and Matsushima, Tatsuya and Polvara, Riccardo},
-  title =        {RoboCup@Home 2024: Rules and Regulations},
-  year =         {2024},
-  howpublished = {\url{https://github.com/RoboCupAtHome/RuleBook/releases/tag/2024.1}},
+                  and Kummert, Johannes and Leonetti, Matteo and Contreras, Luis 
+                  and Hawkin, Alina and Hassouna, Vanessa and Ruegemer, Leroy
+                  and Mitzutani, Akinobu and Ribeiro, Tiago},
+  title =        {RoboCup@Home 2025: Rules and Regulations},
+  year =         {2025},
+  howpublished = {\url{https://github.com/RoboCupAtHome/RuleBook/releases/tag/2024.2}},
 }

--- a/citation.bib
+++ b/citation.bib
@@ -5,5 +5,5 @@
                   and Mitzutani, Akinobu and Ribeiro, Tiago},
   title =        {RoboCup@Home 2025: Rules and Regulations},
   year =         {2025},
-  howpublished = {\url{https://github.com/RoboCupAtHome/RuleBook/releases/tag/2024.2}},
+  howpublished = {\url{https://github.com/RoboCupAtHome/RuleBook/releases/tag/2025.1}},
 }


### PR DESCRIPTION
# Updated citation.bib to Match about.tex

Just a quick fix to make sure the author list in `citation.bib` matches what's in `about.tex`, so everything stays consistent.

Let me know if I missed anyone!