### PR TITLE
Prepare 2025 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-[Current Draft]: https://github.com/RoboCupAtHome/RuleBook/compare/2024.2..HEAD
+[Current Draft]: https://github.com/RoboCupAtHome/RuleBook/compare/2025.1..HEAD
+[2025.1]: https://github.com/RoboCupAtHome/RuleBook/compare/2024.2..2025.1
 [2024.2]: https://github.com/RoboCupAtHome/RuleBook/compare/2024.1..2024.2
 [2024.1]: https://github.com/RoboCupAtHome/RuleBook/compare/2023.2..2024.1
 [2023.2]: https://github.com/RoboCupAtHome/RuleBook/compare/2023.1..2023.2
@@ -11,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ## Rulebook [Current Draft]
 
+## Rulebook [2025.1] - 2025-04-14
 * [#946](https://github.com/RoboCupAtHome/RuleBook/pull/946), [#947](https://github.com/RoboCupAtHome/RuleBook/pull/947): Various small Scoring Changes.
   * Receptionist: The Time of the test only starts after the fist person enters the arena or 2mins after start signal which results in up to two extra minutes for opening the door for the first guest.
 * [#943](https://github.com/RoboCupAtHome/RuleBook/pull/943): New HRI Task `Give Me A Hand` replacing Stickler. Checkout the pull request for more information.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ RuleBook for RoboCup @Home 2025
 [Rulebook](https://robocupathome.github.io/RuleBook/rulebook/master.pdf)  
 [Score sheets](https://robocupathome.github.io/RuleBook/scoresheets/master.pdf)  
 
-The current version for 2025 is **draft**
+The current version for 2025 is **final**; only minor (language) updates and clarifications may be made from now on.
 
 [Changelog](CHANGELOG.md)
 

--- a/setup/active_version.tex
+++ b/setup/active_version.tex
@@ -1,6 +1,6 @@
 \newcommand{\YEAR}{2025}
-\newcommand{\STATE}{Draft}
-%\newcommand{\STATE}{Final}
+%\newcommand{\STATE}{Draft}
+\newcommand{\STATE}{Final}
 %
 % Local Variables:
 % TeX-master: "../Rulebook"


### PR DESCRIPTION
## Description

Changes for the 2025.1 rulebook release.

- update changelog
- set active_version to FINAL
- update README to reflect version is final

## Other comments
TODO Tag this as `2025.1` after merge to create the release.