### PR TITLE
First draft of Restaurant 2026

### DIFF
--- a/scoresheets/Restaurant.tex
+++ b/scoresheets/Restaurant.tex
@@ -5,6 +5,7 @@
 
 	\scoreitem[2]{200}{Understand and confirm the order received to the customer}
 	\scoreitem[2]{100}{Communicate the order to the barman}
+	\scoreitem[2]{200}{Picking up the requested item from the \textit{Kitchen-bar}}
 
 	\scoreitem[2]{100}{Return to the customer table with the order}
 	\scoreitem[2]{200}{Serve the order to the customer}
@@ -19,8 +20,8 @@
 	\penaltyitem[2]{80}{Asking for directional confirmation}
 
 	\scoreheading{Deus ex Machina Penalties}
-	\penaltyitem[4]{50}{Asking the Barman to handover object to the robot}
-	\penaltyitem[4]{50}{Guest needing to take the object from a tray or the robot's hand}
+	\penaltyitem[4]{100}{Asking the Barman to handover object to the robot}
+	\penaltyitem[4]{100}{Guest needing to take the object from a tray or the robot's hand}
 	\penaltyitem[2]{100}{Being told/pointed where is a table/\textit{Kitchen-bar}}
 
 \end{scorelist}

--- a/tasks/Restaurant.tex
+++ b/tasks/Restaurant.tex
@@ -21,7 +21,7 @@ This task focuses on
 	\begin{itemize}
 		\item This task takes place in a real restaurant fully equipped and in business. If this is not possible, an alternative venue may be selected, provided it resembles a restaurant environment and is outside the \Arena{}.
 		\item The \emph{Restaurant} location will remain undisclosed until the start of the test.
-		\item The robot starts next to the \emph{Kitchen-bar}. It is a designated table located near the restaurant's kitchen.
+		\item The robot starts next to the \emph{Kitchen-bar} (a designated table located near the restaurant's kitchen), facing the customer seating area (dining tables).
 	\end{itemize}	 
 	\item \textbf{People:} 
 	\begin{itemize}
@@ -63,7 +63,7 @@ This task focuses on
 		\item Since this task is performed outside the arena, the time limit may be longer than the others tasks.
 		\item The availability of wireless, external computing devices, or electrical outlets can't be guaranteed. Assume unavailability.
 		\item The robot must interact with the customers directly. Teams are not allowed to assist or instruct them.
-		\item The robot may use up to two minutes to instruct the \textit{Professional Barman} per oreder.
+		\item The robot may use up to two minutes to instruct the \textit{Professional Barman} per order.
 		\item Examples of instructions include, but are not limited to:
         \begin{itemize}[nosep]
             \item Request guidance to a customer’s table.


### PR DESCRIPTION
## Description
Updates for Restaurant 2026
To encourage teams to use barman rather than being stuck in the middle of the restaurant.
- increased the time and count to instruct the Barman from one minute for the task to two minutes per order.
- add some examples of instructions
- reduced the penalty score of "Being guided to a table"
- add penalty "Asking for directional confirmation" due to no awareness

I didn't include the barman's guidance/pointing procedure that automatically executed after 1 minute.
Because it will not change the robot's behavior and only make it look worse.