### PR TITLE
Interaction should be scored by the involved persons.

### DIFF
--- a/pages/general_rules/ManipulationChallenge.tex
+++ b/pages/general_rules/ManipulationChallenge.tex
@@ -1,6 +1,0 @@
-\section{Manipulation Challenge}
-\label{sec:rules:manipulationChallenge}
-
-In cooperation with MathWorks and together with the RoboCup@Work league, an additional technical manipulation challenge is offered to \AtHome{} teams starting from 2022. The objective is to use a manipulator, programmed in MATLAB and Simulink, for sorting objects that lie on a table into separate bins near the manipulator. This year, the challenge is simulation-based, using Gazebo as a simulation environment. The overall winner of the challenge will receive a research grant of up to \$5,000; all other participants will receive a certificate of participation.
-
-Teams already registered for RoboCup@Home can participate in the challenge without any additional cost. Note that the challenge does not contribute points towards the overall score of the @Home competition; however, the best @Home team that participates in the challenge may receive a separate certificate for the achievement (even if they are not the overall winner of the challenge). More details about the challenge are provided on the official page: \url{arm.robocup.org}. This includes information about the registration procedure, the competition timeline, and, most importantly, the rules of the challenge.

--- a/pages/general_rules/ScoringInteraction.tex
+++ b/pages/general_rules/ScoringInteraction.tex
@@ -1,0 +1,10 @@
+\section{Scoring Interaction}\label{sec:rules:hri}
+Some tests require interaction with people other than the referees. In such cases the interaction will be scored by the interacting persons.
+Score will only be awarded if the involved people agree that the interaction was successful.
+
+\subsection*{Example}\label{rule:hri_example}
+Example (non-exhaustive):
+\begin{itemize}[noitemsep]
+	\item The refree may ask the person if they understood information provided by the robot.
+    \item The refree may ask the person if the robot held eye contact. 
+\end{itemize}

--- a/pages/general_rules/ScoringInteraction.tex
+++ b/pages/general_rules/ScoringInteraction.tex
@@ -1,10 +1,11 @@
-\section{Scoring Interaction}\label{sec:rules:hri}
-Some tests require interaction with people other than the referees. In such cases the interaction will be scored by the interacting persons.
-Score will only be awarded if the involved people agree that the interaction was successful.
+\section{Scoring Human Robot Interaction}\label{sec:rules:hri}
+In some tests, the robot is required to interact with volunteer participants other than the referees. These volunteers may include team members or individuals from outside the league with no robotics background.
+In such cases, the interaction will be evaluated by the volunteer.
+A score will only be awarded if the volunteer confirms that the interaction was successful.
 
 \subsection*{Example}\label{rule:hri_example}
 Example (non-exhaustive):
 \begin{itemize}[noitemsep]
-	\item The refree may ask the person if they understood information provided by the robot.
-    \item The refree may ask the person if the robot held eye contact. 
+	\item The referee may ask the person if they understood information provided by the robot.
+	\item The referee may ask the person if the robot held eye contact.
 \end{itemize}

--- a/pages/rulebook/GeneralRules.tex
+++ b/pages/rulebook/GeneralRules.tex
@@ -27,6 +27,7 @@ This means that any additional or contrary rules, particularly those related to 
 
 \input{pages/general_rules/ContinueRules}
 \input{pages/general_rules/PenaltiesBonuses}
+\input{pages/general_rules/ScoringInteraction}
 
 \input{pages/general_rules/OpenChallenge}
 


### PR DESCRIPTION
## Description

- it is often hard for the refrees to understand if the robot says the coccrect information or held eye contact
- tasks score items often require the robot to convey information to xx person

In all interactions the score should be awarded if the interacting people feel like the interaction was successfull.

- much easier to refree: ask the involved people, Answer determines score. 'had the robot held eye contact'
- rewards the robot for having good interaction, making sure information gets convejed clear to the conversation partners.
- no more score discussion with the refree: Interaction is subjective and robot has to make sure the interaction is successfull

closes #1031 

Changes proposed in this pull request:
- add Ruling section for "Scoring Interaction"
- add examples:
  - The refree may ask the person if they understood information provided by the robot.
  - The refree may ask the person if the robot held eye contact. 


