### PR TITLE
Restaurant updates from Portugal Open

### DIFF
--- a/scoresheets/Restaurant.tex
+++ b/scoresheets/Restaurant.tex
@@ -1,25 +1,28 @@
 \small\begin{scorelist}[timelimit=15]
 	\scoreheading{Regular Rewards}	
-	\scoreitem[2]{100}{Detect calling or waving customer}
-	\scoreitem[2]{100}{Reach a customer's table}
-		\scorepen[2]{100}{Human Assistance: Being guided to a table}
-	\scoreitem[2]{200}{Understand and confirm the order received to the customer}
-		\scorepen[2]{80}{Not making eye-contact when taking the order}
-	\scoreitem[2]{100}{Communicate the order to the barman}
-	\scoreitem[2]{200}{Picking up the requested items from the \textit{Kitchen-bar}}
+	\scoreitem[2]{80}{Detect calling or waving customer}
+	\scoreitem[2]{80}{Reach a customer's table}
+		\scorepen[2]{80}{Human Assistance: Being guided to a table}
+	\scoreitem[2]{160}{Understand and confirm the order received to the customer}
+		\scorepen[2]{80}{Alternative HRI}
+		\scorepen[2]{60}{Not making eye-contact when taking the order}
+	\scoreitem[2]{80}{Communicate the order to the barman}
+	\scoreitem[4]{100}{Picking up the requested items from the \textit{Kitchen-bar}}
+		\scoremod{100}{First Pick Bonus}
 		\scorepen[4]{100}{Human assistance: Asking the Barman to handover object to the robot}
 
-	\scoreitem[2]{100}{Return to the customer table with the order}
-	\scoreitem[2]{200}{Serve the order to the customer}
+	\scoreitem[2]{80}{Return to the customer table with the order}
+	\scoreitem[4]{100}{Serve the order to the customer}
+		\scoremod{100}{First Place Bonus}
 		\scorepen[4]{100}{Human assistance: Guest needing to take the object from a tray or the robot's hand}
 
 	\scoreheading{Extra Rewards}
 	\scoreitem[2]{200}{Use an unattached tray to transport}
 
 	\scoreheading{Penalties}
-	\penaltyitem[2]{80}{Not reaching the bar (barman has to move from behind the bar to interact with the robot)}
-	\penaltyitem[2]{40}{Human Assistance: Asking for directional confirmation}
-	\penaltyitem[2]{50}{Human Assistance: Being told/pointed where a table/\textit{Kitchen-bar} is located}
+	\penaltyitem[2]{60}{Not reaching the bar (barman has to move from behind the bar to interact with the robot)}
+	\penaltyitem[2]{30}{Human Assistance: Asking for directional confirmation}
+	\penaltyitem[2]{40}{Human Assistance: Being told/pointed where a table/\textit{Kitchen-bar} is located}
 
 \end{scorelist}
 

--- a/tasks/Restaurant.tex
+++ b/tasks/Restaurant.tex
@@ -68,6 +68,7 @@ Teams are allowed a single restart during the restaurant task. The following rul
 
 \subsection*{Additional rules and remarks}
 \begin{itemize}
+	\item \textbf{Alternative HRI:} Using an alternative HRI to understand an order causes a score reduction.
 	\item \textbf{Remarks:}
 	\begin{itemize}
 		\item This test occurs in a public area. Any physical contact with people or furniture results in immediate emergency stop.

--- a/tasks/Restaurant.tex
+++ b/tasks/Restaurant.tex
@@ -98,7 +98,6 @@ Teams are allowed a single restart during the restaurant task. The following rul
 		\item If requested, the \textit{Professional Barman} will place the order in a basket or tray for the robot to deliver it.
 		\item Only two team members are allowed near the robot upon arrival for watching and charging.
 		\item If audience interference makes task execution impossible, the team may immediately repeat the test.
-		\item Each human assistance penalty for skipping manipulation is capped at twice per order so receiving an order with three objects is not more punishing.
 		\item If the robot detects a customer but does not reach their table, it must clearly identify the person (e.g., show a picture) to earn partial points.
 		\item When at the front of the queue, teams may begin startup procedures with the robot stationary. Once called, the robot must be brought directly and steadily to the start location—only minor adjustments are allowed (no back-and-forth or full turns).
 	\end{itemize}

--- a/tasks/Restaurant.tex
+++ b/tasks/Restaurant.tex
@@ -68,7 +68,7 @@ Teams are allowed a single restart during the restaurant task. The following rul
 
 \subsection*{Additional rules and remarks}
 \begin{itemize}
-	\item \textbf{First Pick/Place Bonus:} The robot receives an additional bonus for successfully picking an placing the first object during the test. This bonus is awarded only once.
+	\item \textbf{First Pick/Place Bonus:} The robot receives an additional bonus for successfully picking and placing the first object during the test. This bonus is awarded only once.
 	\item \textbf{Alternative HRI:} Using an alternative HRI to understand an order causes a score reduction.
 	\item \textbf{Remarks:}
 	\begin{itemize}

--- a/tasks/Restaurant.tex
+++ b/tasks/Restaurant.tex
@@ -68,6 +68,7 @@ Teams are allowed a single restart during the restaurant task. The following rul
 
 \subsection*{Additional rules and remarks}
 \begin{itemize}
+	\item \textbf{First Pick/Place Bonus:} The robot receives an additional bonus for successfully picking an placing the first object during the test. This bonus is awarded only once.
 	\item \textbf{Alternative HRI:} Using an alternative HRI to understand an order causes a score reduction.
 	\item \textbf{Remarks:}
 	\begin{itemize}


### PR DESCRIPTION
Updated the picking and placing scoring items from 2x200 to 4x100
20% reduction on all non manipulation tasks
Added +100 bonus for first picking and first placing (same as in PP to motivate teams to attempt manipulation)
Added scoresheet penalty for using alternative HRI for understanding the order (it was in the rulebook but not in scoresheet, hidden rule now is clearer)
Removed legacy remark of three items in order.