### PR TITLE
Clarify ruling on tool use during test.

### DIFF
--- a/pages/general_rules/ExternalDevices.tex
+++ b/pages/general_rules/ExternalDevices.tex
@@ -3,6 +3,8 @@
 Everything that a team uses during a test and is not part of the robot is considered an \ExternalDevice{}.
 All \ExternalDevices{} must be authorized by the \TC{} during the \RobotInspection{} test (see~\refsec{sec:robot_inspection}).
 The TC specifies whether an \ExternalDevice{} can be used freely or under referee supervision, and determines its impact on scoring.
+The use of tools is allowed but a robot, for example, starting a test with a tool in hand counts as a different configuration under Rule \ref{rule:robots_number}. During \RobotInspection \ the referee will make sure that such a tool is securely attached to the robot. 
+A custom container as mentioned in \ref{sec:robot_inspection} is an exception to this rule.
 
 \textbf{Note:} The use of wireless devices, such as hand microphones and headsets, is not allowed, with the exception of \ExternalComputing{} as specified below.
 The competition organizers do not guarantee or take any responsibility for the availability or reliability of the network or the internet connection in the \Arena{}.

--- a/pages/general_rules/Robots.tex
+++ b/pages/general_rules/Robots.tex
@@ -3,7 +3,7 @@
 \subsection{Number of Robots}\label{rule:robots_number}
 
 \begin{enumerate}
-	\item \textbf{Registration:} The maximum \term{number of robots} per team is \emph{two}.
+	\item \textbf{Registration:} The maximum \term{number of robots} per team is \emph{two}. Note, that a different configuration of a robot (i.e. alternative gripper) counts as a second robot. A robot needs to pass \RobotInspection \ in both configurations.
 	\item \textbf{Regular Tests:} Only one robot is allowed per test. Different robots can be used for different test runs.
 \end{enumerate}
 


### PR DESCRIPTION
Starting with tool in hand counts as different robot configuration. This means it counts as a second robot and needs to pass Inspection. Container for Restaraurant remains an exception to this.

