### PR TITLE
Introduce humanoid robot rules and safety crane guidelines

### DIFF
--- a/pages/general_rules/Robots.tex
+++ b/pages/general_rules/Robots.tex
@@ -21,6 +21,10 @@ Robots competing in the RoboCup@Home League must comply with security specificat
 \end{enumerate}
 The compliance with these rules will be verified during \RobotInspection{} (see \ref{sec:robot_inspection}).
 
+Humanoid Robots (2026): Legged humanoid robots are introduced to RoboCup@Home for the first time in 2026. Due to safety considerations, teams are permitted to use a safety crane/hanger system during task execution. The crane may be operated by one designated team member. This operator may only handle the crane and must not make physical contact with the robot at any time. Any direct contact between the operator and the robot will result in the immediate termination of the task.
+Any major collision between the robot and the crane structure will be treated as a robot collision and will result in task termination. The crane operator is responsible for maneuvering the crane safely around the robot and the environment. Minor contact between the crane and door frames is permitted while passing through doorways. Outside of this exception, any major collision between the crane and the environment will be considered a collision and result in task termination.
+Teams are responsible for ensuring that both the robot and the crane system can safely navigate all competition spaces, including passing through doorways and other environmental constraints.
+
 \subsubsection{Size and Weight}\label{rule:robots_size}
 
 \begin{enumerate}


### PR DESCRIPTION
Added rule for humanoid robots and safety crane usage in RoboCup@Home.

** Note: Your contribution is expected to meet the conventions and policies described in the [contribution guidelines](https://github.com/RoboCupAtHome/RuleBook/wiki/Guidelines:-Contributing) **

## Description

Due to some of the humanoids being a safety concern due to size weight this year, I propose to allow restricted use of cranes during competition. It has been discussed in early May  and this is a small change to accommodate that. 

Changes proposed in this pull request:
- Allow for a crane with a team member as an operator